### PR TITLE
Use the asdf-schema-helpers package pytest helper

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ setup_requires =
 test =
     pytest
     asdf
+    asdf_schema_helpers @ git+https://github.com/asdf-format/asdf-schema-helpers
 
 [options.package_data]
 * = *.yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ license_file = LICENSE
 description = ASDF schemas for transforms
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/spacetelescope/asdf-transform-schemas
+url = https://github.com/asdf-format/asdf-transform-schemas
 
 [options]
 python_requires = >=3.6
@@ -30,11 +30,11 @@ asdf_extensions =
 
 [tool:pytest]
 asdf_schema_root = schemas
-asdf_schema_tests_enabled = true
 asdf_schema_ignore_unrecognized_tag = true
 testpaths =
     tests
     schemas
+addopts = --asdf-schema
 
 [flake8]
 ignore = E501, E203, W503

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py38, black, flake8
 
 [testenv]
+usedevelop = True
 extras =
     test
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist = py38, black, flake8
 extras =
     test
 commands =
-    pip install git+https://github.com/asdf-format/asdf-schema-helpers
     pytest
 
 [testenv:black]

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py38, black, flake8
 extras =
     test
 commands =
+    pip install git+https://github.com/asdf-format/asdf-schema-helpers
     pytest
 
 [testenv:black]


### PR DESCRIPTION
This uses the pytest plugin from `asdf-schema-helpers` instead of the one bundled with `asdf`.

Since the plugin is not yet released, we need to install from Github, which means it cannot be listed in the `[test]` extras and instead needs to be explicitly installed in the tox env.