### PR TITLE
Create manifest files for existing transform extensions

### DIFF
--- a/resources/stsci.edu/manifests/transform-1.0.0.yaml
+++ b/resources/stsci.edu/manifests/transform-1.0.0.yaml
@@ -1,0 +1,680 @@
+id: http://stsci.edu/asdf/extensions/transform/manifests/transform-1.0.0
+extension_uri: http://stsci.edu/asdf/extensions/transform-1.0.0
+title: Transform extension 1.0.0
+description: |-
+  A set of tags for serializing data transforms.
+asdf_standard_requirement: 1.0.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/transform/add-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.0.0
+  title: Perform a list of subtransforms in parallel and then add their results together.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+- tag_uri: tag:stsci.edu:asdf/transform/affine-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/affine-1.0.0
+  title: An affine transform.
+  description: |-
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/airy-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/airy-1.0.0
+  title: The Airy projection.
+  description: |-
+    Corresponds to the `AIR` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:http://stsci.edu/schemas/asdf/transform/zenithal-1.0.0)
+    for the definition of the full transformation.
+- tag_uri: tag:stsci.edu:asdf/transform/bonne_equal_area-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/bonne_equal_area-1.0.0
+  title: Bonne's equal area pseudoconic projection.
+  description: |-
+    Corresponds to the `BON` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi}{180^\circ} A_\phi R_\theta / \cos \theta \\
+      \theta &= Y_0 - R_\theta$$
+
+    where:
+
+    $$R_\theta &= \mathrm{sign} \theta_1 \sqrt{x^2 + (Y_0 - y)^2} \\
+      A_\phi &= \arg\left(\frac{Y_0 - y}{R_\theta}, \frac{x}{R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R_\theta \sin A_\phi \\
+      y &= -R_\theta \cos A_\phi + Y_0$$
+
+    where:
+
+    $$A_\phi &= \frac{180^\circ}{\pi R_\theta} \phi \cos \theta \\
+      R_\theta &= Y_0 - \theta \\
+      Y_0 &= \frac{180^\circ}{\pi} \cot \theta_1 + \theta_1$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/cobe_quad_spherical_cube-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cobe_quad_spherical_cube-1.0.0
+  title: COBE quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `CSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/compose-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/compose-1.0.0
+  title: Perform a list of subtransforms in series.
+  description: |-
+    The output of each subtransform is fed into the input of the next
+    subtransform.
+
+    The number of output dimensions of each subtransform must be equal
+    to the number of input dimensions of the next subtransform in list.
+    To reorder or add/drop axes, insert `remap_axes` transforms in the
+    subtransform list.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform, by reversing the list of
+    transforms and applying the inverse of each.
+- tag_uri: tag:stsci.edu:asdf/transform/concatenate-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/concatenate-1.0.0
+  title: Send axes to different subtransforms.
+  description: |-
+    Transforms a set of separable inputs by splitting the axes apart,
+    sending them through the given subtransforms in parallel, and
+    finally concatenating the subtransform output axes back together.
+
+    The input axes are assigned to each subtransform in order.  If the
+    number of input axes is unequal to the sum of the number of input
+    axes of all of the subtransforms, that is considered an error case.
+
+    The output axes from each subtransform are appended together to make
+    up the resulting output axes.
+
+    For example, given 5 input axes, and 3 subtransforms with the
+    following orders:
+
+    1. transform A: 2 in -> 2 out
+    1. transform B: 1 in -> 2 out
+    1. transform C: 2 in -> 1 out
+
+    The transform is performed as follows:
+
+    ```
+      :    i0    i1       i2       i3    i4
+      :    |     |        |        |     |
+      :  +---------+ +---------+ +----------+
+      :  |    A    | |    B    | |    C     |
+      :  +---------+ +---------+ +----------+
+      :    |     |     |     |        |
+      :    o0    o1    o2    o3       o4
+    ```
+
+    If reordering of the input or output axes is required, use in series
+    with the `remap_axes` transform.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equal_area-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equal_area-1.0.0
+  title: Alber's conic equal area projection.
+  description: |-
+    Corresponds to the `COE` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:http://stsci.edu/schemas/asdf/transform/conic-1.0.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \gamma / 2 \\
+      R_\theta &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin \theta} \\
+      Y_0 &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin((\theta_1 + \theta_2)/2)}$$
+
+    where:
+
+    $$\gamma = \sin \theta_1 + \sin \theta_2$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equidistant-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equidistant-1.0.0
+  title: Conic equidistant projection.
+  description: |-
+    Corresponds to the `COD` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:http://stsci.edu/schemas/asdf/transform/conic-1.0.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{180^\circ}{\pi} \frac{\sin\theta_a\sin\eta}{\eta} \\
+      R_\theta &= \theta_a - \theta + \eta\cot\eta\cot\theta_a \\
+      Y_0 = \eta\cot\eta\cot\theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_orthomorphic-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_orthomorphic-1.0.0
+  title: Conic orthomorphic projection.
+  description: |-
+    Corresponds to the `COO` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:http://stsci.edu/schemas/asdf/transform/conic-1.0.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{\ln \left( \frac{\cos\theta_2}{\cos\theta_1} \right)}
+                {\ln \left[ \frac{\tan\left(\frac{90^\circ-\theta_2}{2}\right)}
+                                 {\tan\left(\frac{90^\circ-\theta_1}{2}\right)} \right] } \\
+      R_\theta &= \psi \left[ \tan \left( \frac{90^\circ - \theta}{2} \right) \right]^C \\
+      Y_0 &= \psi \left[ \tan \left( \frac{90^\circ - \theta_a}{2} \right) \right]^C$$
+
+    where:
+
+    $$\psi = \frac{180^\circ}{\pi} \frac{\cos \theta}
+             {C\left[\tan\left(\frac{90^\circ-\theta}{2}\right)\right]^C}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_perspective-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_perspective-1.0.0
+  title: Colles' conic perspecitve projection.
+  description: |-
+    Corresponds to the `COP` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:http://stsci.edu/schemas/asdf/transform/conic-1.0.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \sin \theta_a \\
+      R_\theta &= \frac{180^\circ}{\pi} \cos \eta [ \cot \theta_a - \tan(\theta - \theta_a)] \\
+      Y_0 &= \frac{180^\circ}{\pi} \cos \eta \cot \theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/constant-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/constant-1.0.0
+  title: A transform that takes no inputs and always outputs a constant value.
+  description: |-
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform, which always outputs zero values.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_equal_area-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_equal_area-1.0.0
+  title: The cylindrical equal area projection.
+  description: |-
+    Corresponds to the `CEA` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= \sin^{-1}\left(\frac{\pi}{180^{\circ}}\lambda y\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\frac{\sin \theta}{\lambda}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_perspective-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_perspective-1.0.0
+  title: The cylindrical perspective projection.
+  description: |-
+    Corresponds to the `CYP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\lambda} \\
+    \theta &= \arg(1, \eta) + \sin{-1}\left(\frac{\eta \mu}{\sqrt{\eta^2 + 1}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \lambda \phi \\
+    y &= \frac{180^{\circ}}{\pi}\left(\frac{\mu + \lambda}{\mu + \cos \theta}\right)\sin \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/divide-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/divide-1.0.0
+  title: Perform a list of subtransforms in parallel and then divide their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/domain-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/domain-1.0.0
+  title: Defines the domain of an input axis. (deprecated since 1.1.0)
+  description: |-
+    Describes the range of acceptable input values to a particular axis of a transform.
+- tag_uri: tag:stsci.edu:asdf/transform/generic-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/generic-1.0.0
+  title: A generic transform.
+  description: |-
+    This is used **entirely** for bootstrapping purposes so one can create composite models including transforms that haven't yet been written.  **IT WILL NOT BE IN THE FINAL VERSION OF THE SPEC**.
+- tag_uri: tag:stsci.edu:asdf/transform/gnomonic-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/gnomonic-1.0.0
+  title: The gnomonic projection.
+  description: |-
+    Corresponds to the `TAN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:http://stsci.edu/schemas/asdf/transform/zenithal-1.0.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/hammer_aitoff-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/hammer_aitoff-1.0.0
+  title: Hammer-Aitoff projection.
+  description: |-
+    Corresponds to the `AIT` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= 2 \arg \left(2Z^2 - 1, \frac{\pi}{180^\circ} \frac{Z}{2}x\right) \\
+      \theta &= \sin^{-1}\left(\frac{\pi}{180^\circ}yZ\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= 2 \gamma \cos \theta \sin \frac{\phi}{2} \\
+      y &= \gamma \sin \theta$$
+
+    where:
+
+    $$\gamma = \frac{180^\circ}{\pi} \sqrt{\frac{2}{1 + \cos \theta \cos(\phi / 2)}}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix-1.0.0
+  title: HEALPix projection.
+  description: |-
+    Corresponds to the `HPX` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix_polar-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix_polar-1.0.0
+  title: HEALPix polar, aka "butterfly", projection.
+  description: |-
+    Corresponds to the `XPH` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/identity-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/identity-1.0.0
+  title: The identity transform.
+  description: |-
+    Invertibility: The inverse of this transform is also the identity transform.
+- tag_uri: tag:stsci.edu:asdf/transform/label_mapper-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/label_mapper-1.0.0
+  title: Represents a mapping from a coordinate value to a label.
+  description: |-
+    A label mapper instance maps inputs to a label.  It is used together
+    with
+    [regions_selector](ref:http://stsci.edu/schemas/asdf/transform/regions_selector-1.0.0). The
+    [label_mapper](ref:http://stsci.edu/schemas/asdf/transform/label_mapper-1.0.0)
+    returns the label corresponding to given inputs. The
+    [regions_selector](ref:http://stsci.edu/schemas/asdf/transform/regions_selector-1.0.0)
+    returns the transform corresponding to this label. This maps inputs
+    (e.g. pixels on a detector) to transforms uniquely.
+- tag_uri: tag:stsci.edu:asdf/transform/mercator-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/mercator-1.0.0
+  title: The Mercator projection.
+  description: |-
+    Corresponds to the `MER` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= 2 \tan^{-1}\left(e^{y \pi / 180^{\circ}}\right)-90^{\circ}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\ln \tan \left(\frac{90^{\circ} + \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/molleweide-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/molleweide-1.0.0
+  title: Molleweide's projection.
+  description: |-
+    Corresponds to the `MOL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi x}{2 \sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}} \\
+      \theta &= \sin^{-1}\left(\frac{1}{90^\circ}\sin^{-1}\left(\frac{\pi}{180^\circ}\frac{y}{\sqrt{2}}\right) + \frac{y}{180^\circ}\sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \frac{2 \sqrt{2}}{\pi} \phi \cos \gamma \\
+      y &= \sqrt{2} \frac{180^\circ}{\pi} \sin \gamma$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/multiply-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/multiply-1.0.0
+  title: Perform a list of subtransforms in parallel and then multiply their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/parabolic-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/parabolic-1.0.0
+  title: Parabolic projection.
+  description: |-
+    Corresponds to the `PAR` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{180^\circ}{\pi} \frac{x}{1 - 4(y / 180^\circ)^2} \\
+      \theta &= 3 \sin^{-1}\left(\frac{y}{180^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \left(2\cos\frac{2\theta}{3} - 1\right) \\
+      y &= 180^\circ \sin \frac{\theta}{3}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/plate_carree-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/plate_carree-1.0.0
+  title: "The plate carr\xE9e projection."
+  description: |-
+    Corresponds to the `CAR` projection in the FITS WCS standard.
+
+    The main virtue of this transformation is its simplicity.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/polyconic-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polyconic-1.0.0
+  title: Polyconic projection.
+  description: |-
+    Corresponds to the `PCO` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/polynomial-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polynomial-1.0.0
+  title: A Polynomial model.
+  description: |-
+    A polynomial model represented by its coefficients stored in
+    an ndarray of shape $(n+1)$ for univariate polynomials or $(n+1, n+1)$
+    for polynomials with 2 variables, where $n$ is the highest total degree
+    of the polynomial.
+
+    $$P = \sum_{i, j=0}^{i+j=n}c_{ij} * x^{i} * y^{j}$$
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/power-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/power-1.0.0
+  title: Perform a list of subtransforms in parallel and then raise each result to
+    the power of the next.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/quad_spherical_cube-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/quad_spherical_cube-1.0.0
+  title: Quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `QSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/regions_selector-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/regions_selector-1.0.0
+  title: Represents a discontinuous transform.
+  description: |-
+    Maps regions to transgorms and evaluates the transforms with the corresponding inputs.
+- tag_uri: tag:stsci.edu:asdf/transform/remap_axes-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/remap_axes-1.0.0
+  title: Reorder, add and drop axes.
+  description: |-
+    This transform allows the order of the input axes to be shuffled and
+    returned as the output axes.
+
+    It is a list made up of integers or "constant markers".  Each item
+    in the list corresponds to an output axis.  For each item:
+
+    - If an integer, it is the index of the input axis to send to the
+      output axis.
+
+    - If a constant, it must be a single item which is a constant value
+      to send to the output axis.
+
+    If only a list is provided, the number of input axes is
+    automatically determined from the maximum index in the list.  If an
+    object with `mapping` and `n_inputs` properties is provided, the
+    number of input axes is explicitly set by the `n_inputs` value.
+
+    Invertibility: TBD
+- tag_uri: tag:stsci.edu:asdf/transform/rotate2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate2d-1.0.0
+  title: A 2D rotation.
+  description: |-
+    A 2D rotation around the origin, in degrees.
+    Invertibility: All ASDF tools are required to be able to compute the analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/rotate3d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate3d-1.0.0
+  title: Rotation in 3D space.
+  description: |-
+    Euler angle rotation around 3 axes.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/sanson_flamsteed-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/sanson_flamsteed-1.0.0
+  title: The Sanson-Flamsteed projection.
+  description: |-
+    Corresponds to the `SFL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\cos y} \\
+      \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \cos \theta \\
+      y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/scale-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/scale-1.0.0
+  title: A Scale model.
+  description: |-
+    Multiply the input by a factor.
+- tag_uri: tag:stsci.edu:asdf/transform/shift-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/shift-1.0.0
+  title: A Shift opeartion.
+  description: |-
+    Apply an offset in one direction.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_orthographic-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_orthographic-1.0.0
+  title: The slant orthographic projection.
+  description: |-
+    Corresponds to the `SIN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:http://stsci.edu/schemas/asdf/transform/zenithal-1.0.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \cos^{-1}\left(\frac{\pi}{180^{\circ}}R_\theta\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cos \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_zenithal_perspective-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_zenithal_perspective-1.0.0
+  title: The slant zenithal perspective projection.
+  description: |-
+    Corresponds to the `SZP` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:http://stsci.edu/schemas/asdf/transform/zenithal-1.0.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/stereographic-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/stereographic-1.0.0
+  title: The stereographic projection.
+  description: |-
+    Corresponds to the `STG` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:http://stsci.edu/schemas/asdf/transform/zenithal-1.0.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^{\circ} - 2 \tan^{-1}\left(\frac{\pi R_\theta}{360^{\circ}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\frac{2 \cos \theta}{1 + \sin \theta}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/subtract-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/subtract-1.0.0
+  title: Perform a list of subtransforms in parallel and then subtract their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/tabular-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tabular-1.0.0
+  title: A Tabular model.
+  description: |-
+    Tabular represents a lookup table with values corresponding to
+    some grid points.
+    It computes the interpolated values corresponding to the given
+    inputs. Three methods of interpolation are supported -
+    "linear", "nearest" and "splinef2d". It supports extrapolation.
+- tag_uri: tag:stsci.edu:asdf/transform/tangential_spherical_cube-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tangential_spherical_cube-1.0.0
+  title: Tangential spherical cube projection.
+  description: |-
+    Corresponds to the `TSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equal_area-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equal_area-1.0.0
+  title: The zenithal equal area projection.
+  description: |-
+    Corresponds to the `ZEA` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:http://stsci.edu/schemas/asdf/transform/zenithal-1.0.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - 2 \sin^{-1} \left(\frac{\pi R_\theta}{360^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta &= \frac{180^\circ}{\pi} \sqrt{2(1 - \sin\theta)} \\
+               &= \frac{360^\circ}{\pi} \sin\left(\frac{90^\circ - \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equidistant-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equidistant-1.0.0
+  title: The zenithal equidistant projection.
+  description: |-
+    Corresponds to the `ARC` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:http://stsci.edu/schemas/asdf/transform/zenithal-1.0.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - R_\theta$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = 90^\circ - \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_perspective-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_perspective-1.0.0
+  title: The zenithal perspective projection.
+  description: |-
+    Corresponds to the `AZP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \arg(-y \cos \gamma, x) \\
+    \theta &= \left\{\genfrac{}{}{0pt}{}{\psi - \omega}{\psi + \omega + 180^{\circ}}\right.$$
+
+    where:
+
+    $$\psi &= \arg(\rho, 1) \\
+    \omega &= \sin^{-1}\left(\frac{\rho \mu}{\sqrt{\rho^2 + 1}}\right) \\
+    \rho &= \frac{R}{\frac{180^{\circ}}{\pi}(\mu + 1) + y \sin \gamma} \\
+    R &= \sqrt{x^2 + y^2 \cos^2 \gamma}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R \sin \phi \\
+    y &= -R \sec \gamma \cos \theta$$
+
+    where:
+
+    $$R = \frac{180^{\circ}}{\pi} \frac{(\mu + 1) \cos \theta}{(\mu + \sin \theta) + \cos \theta \cos \phi \tan \gamma}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.

--- a/resources/stsci.edu/manifests/transform-1.1.0.yaml
+++ b/resources/stsci.edu/manifests/transform-1.1.0.yaml
@@ -1,0 +1,675 @@
+id: http://stsci.edu/asdf/extensions/transform/manifests/transform-1.1.0
+extension_uri: http://stsci.edu/asdf/extensions/transform-1.1.0
+title: Transform extension 1.1.0
+description: |-
+  A set of tags for serializing data transforms.
+asdf_standard_requirement: 1.1.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/transform/add-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.1.0
+  title: Perform a list of subtransforms in parallel and then add their results together.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+- tag_uri: tag:stsci.edu:asdf/transform/affine-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/affine-1.1.0
+  title: An affine transform.
+  description: |-
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/airy-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/airy-1.1.0
+  title: The Airy projection.
+  description: |-
+    Corresponds to the `AIR` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+- tag_uri: tag:stsci.edu:asdf/transform/bonne_equal_area-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/bonne_equal_area-1.1.0
+  title: Bonne's equal area pseudoconic projection.
+  description: |-
+    Corresponds to the `BON` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi}{180^\circ} A_\phi R_\theta / \cos \theta \\
+      \theta &= Y_0 - R_\theta$$
+
+    where:
+
+    $$R_\theta &= \mathrm{sign} \theta_1 \sqrt{x^2 + (Y_0 - y)^2} \\
+      A_\phi &= \arg\left(\frac{Y_0 - y}{R_\theta}, \frac{x}{R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R_\theta \sin A_\phi \\
+      y &= -R_\theta \cos A_\phi + Y_0$$
+
+    where:
+
+    $$A_\phi &= \frac{180^\circ}{\pi R_\theta} \phi \cos \theta \\
+      R_\theta &= Y_0 - \theta \\
+      Y_0 &= \frac{180^\circ}{\pi} \cot \theta_1 + \theta_1$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/cobe_quad_spherical_cube-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cobe_quad_spherical_cube-1.1.0
+  title: COBE quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `CSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/compose-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/compose-1.1.0
+  title: Perform a list of subtransforms in series.
+  description: |-
+    The output of each subtransform is fed into the input of the next
+    subtransform.
+
+    The number of output dimensions of each subtransform must be equal
+    to the number of input dimensions of the next subtransform in list.
+    To reorder or add/drop axes, insert `remap_axes` transforms in the
+    subtransform list.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform, by reversing the list of
+    transforms and applying the inverse of each.
+- tag_uri: tag:stsci.edu:asdf/transform/concatenate-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/concatenate-1.1.0
+  title: Send axes to different subtransforms.
+  description: |-
+    Transforms a set of separable inputs by splitting the axes apart,
+    sending them through the given subtransforms in parallel, and
+    finally concatenating the subtransform output axes back together.
+
+    The input axes are assigned to each subtransform in order.  If the
+    number of input axes is unequal to the sum of the number of input
+    axes of all of the subtransforms, that is considered an error case.
+
+    The output axes from each subtransform are appended together to make
+    up the resulting output axes.
+
+    For example, given 5 input axes, and 3 subtransforms with the
+    following orders:
+
+    1. transform A: 2 in -> 2 out
+    1. transform B: 1 in -> 2 out
+    1. transform C: 2 in -> 1 out
+
+    The transform is performed as follows:
+
+    ```
+      :    i0    i1       i2       i3    i4
+      :    |     |        |        |     |
+      :  +---------+ +---------+ +----------+
+      :  |    A    | |    B    | |    C     |
+      :  +---------+ +---------+ +----------+
+      :    |     |     |     |        |
+      :    o0    o1    o2    o3       o4
+    ```
+
+    If reordering of the input or output axes is required, use in series
+    with the `remap_axes` transform.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equal_area-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equal_area-1.1.0
+  title: Alber's conic equal area projection.
+  description: |-
+    Corresponds to the `COE` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:http://stsci.edu/schemas/asdf/transform/conic-1.1.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \gamma / 2 \\
+      R_\theta &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin \theta} \\
+      Y_0 &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin((\theta_1 + \theta_2)/2)}$$
+
+    where:
+
+    $$\gamma = \sin \theta_1 + \sin \theta_2$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equidistant-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equidistant-1.1.0
+  title: Conic equidistant projection.
+  description: |-
+    Corresponds to the `COD` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:http://stsci.edu/schemas/asdf/transform/conic-1.1.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{180^\circ}{\pi} \frac{\sin\theta_a\sin\eta}{\eta} \\
+      R_\theta &= \theta_a - \theta + \eta\cot\eta\cot\theta_a \\
+      Y_0 = \eta\cot\eta\cot\theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_orthomorphic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_orthomorphic-1.1.0
+  title: Conic orthomorphic projection.
+  description: |-
+    Corresponds to the `COO` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:http://stsci.edu/schemas/asdf/transform/conic-1.1.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{\ln \left( \frac{\cos\theta_2}{\cos\theta_1} \right)}
+                {\ln \left[ \frac{\tan\left(\frac{90^\circ-\theta_2}{2}\right)}
+                                 {\tan\left(\frac{90^\circ-\theta_1}{2}\right)} \right] } \\
+      R_\theta &= \psi \left[ \tan \left( \frac{90^\circ - \theta}{2} \right) \right]^C \\
+      Y_0 &= \psi \left[ \tan \left( \frac{90^\circ - \theta_a}{2} \right) \right]^C$$
+
+    where:
+
+    $$\psi = \frac{180^\circ}{\pi} \frac{\cos \theta}
+             {C\left[\tan\left(\frac{90^\circ-\theta}{2}\right)\right]^C}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_perspective-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_perspective-1.1.0
+  title: Colles' conic perspecitve projection.
+  description: |-
+    Corresponds to the `COP` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:http://stsci.edu/schemas/asdf/transform/conic-1.1.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \sin \theta_a \\
+      R_\theta &= \frac{180^\circ}{\pi} \cos \eta [ \cot \theta_a - \tan(\theta - \theta_a)] \\
+      Y_0 &= \frac{180^\circ}{\pi} \cos \eta \cot \theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/constant-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/constant-1.1.0
+  title: A transform that takes no inputs and always outputs a constant value.
+  description: |-
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform, which always outputs zero values.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_equal_area-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_equal_area-1.1.0
+  title: The cylindrical equal area projection.
+  description: |-
+    Corresponds to the `CEA` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= \sin^{-1}\left(\frac{\pi}{180^{\circ}}\lambda y\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\frac{\sin \theta}{\lambda}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_perspective-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_perspective-1.1.0
+  title: The cylindrical perspective projection.
+  description: |-
+    Corresponds to the `CYP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\lambda} \\
+    \theta &= \arg(1, \eta) + \sin{-1}\left(\frac{\eta \mu}{\sqrt{\eta^2 + 1}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \lambda \phi \\
+    y &= \frac{180^{\circ}}{\pi}\left(\frac{\mu + \lambda}{\mu + \cos \theta}\right)\sin \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/divide-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/divide-1.1.0
+  title: Perform a list of subtransforms in parallel and then divide their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/generic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/generic-1.1.0
+  title: A generic transform.
+  description: |-
+    This is used **entirely** for bootstrapping purposes so one can create composite models including transforms that haven't yet been written.  **IT WILL NOT BE IN THE FINAL VERSION OF THE SPEC**.
+- tag_uri: tag:stsci.edu:asdf/transform/gnomonic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/gnomonic-1.1.0
+  title: The gnomonic projection.
+  description: |-
+    Corresponds to the `TAN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/hammer_aitoff-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/hammer_aitoff-1.1.0
+  title: Hammer-Aitoff projection.
+  description: |-
+    Corresponds to the `AIT` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= 2 \arg \left(2Z^2 - 1, \frac{\pi}{180^\circ} \frac{Z}{2}x\right) \\
+      \theta &= \sin^{-1}\left(\frac{\pi}{180^\circ}yZ\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= 2 \gamma \cos \theta \sin \frac{\phi}{2} \\
+      y &= \gamma \sin \theta$$
+
+    where:
+
+    $$\gamma = \frac{180^\circ}{\pi} \sqrt{\frac{2}{1 + \cos \theta \cos(\phi / 2)}}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix-1.1.0
+  title: HEALPix projection.
+  description: |-
+    Corresponds to the `HPX` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix_polar-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix_polar-1.1.0
+  title: HEALPix polar, aka "butterfly", projection.
+  description: |-
+    Corresponds to the `XPH` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/identity-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/identity-1.1.0
+  title: The identity transform.
+  description: |-
+    Invertibility: The inverse of this transform is also the identity transform.
+- tag_uri: tag:stsci.edu:asdf/transform/label_mapper-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/label_mapper-1.1.0
+  title: Represents a mapping from a coordinate value to a label.
+  description: |-
+    A label mapper instance maps inputs to a label.  It is used together
+    with
+    [regions_selector](ref:transform/regions_selector-1.1.0). The
+    [label_mapper](ref:transform/label_mapper-1.1.0)
+    returns the label corresponding to given inputs. The
+    [regions_selector](ref:transform/regions_selector-1.1.0)
+    returns the transform corresponding to this label. This maps inputs
+    (e.g. pixels on a detector) to transforms uniquely.
+- tag_uri: tag:stsci.edu:asdf/transform/mercator-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/mercator-1.1.0
+  title: The Mercator projection.
+  description: |-
+    Corresponds to the `MER` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= 2 \tan^{-1}\left(e^{y \pi / 180^{\circ}}\right)-90^{\circ}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\ln \tan \left(\frac{90^{\circ} + \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/molleweide-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/molleweide-1.1.0
+  title: Molleweide's projection.
+  description: |-
+    Corresponds to the `MOL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi x}{2 \sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}} \\
+      \theta &= \sin^{-1}\left(\frac{1}{90^\circ}\sin^{-1}\left(\frac{\pi}{180^\circ}\frac{y}{\sqrt{2}}\right) + \frac{y}{180^\circ}\sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \frac{2 \sqrt{2}}{\pi} \phi \cos \gamma \\
+      y &= \sqrt{2} \frac{180^\circ}{\pi} \sin \gamma$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/multiply-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/multiply-1.1.0
+  title: Perform a list of subtransforms in parallel and then multiply their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/parabolic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/parabolic-1.1.0
+  title: Parabolic projection.
+  description: |-
+    Corresponds to the `PAR` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{180^\circ}{\pi} \frac{x}{1 - 4(y / 180^\circ)^2} \\
+      \theta &= 3 \sin^{-1}\left(\frac{y}{180^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \left(2\cos\frac{2\theta}{3} - 1\right) \\
+      y &= 180^\circ \sin \frac{\theta}{3}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/plate_carree-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/plate_carree-1.1.0
+  title: "The plate carr\xE9e projection."
+  description: |-
+    Corresponds to the `CAR` projection in the FITS WCS standard.
+
+    The main virtue of this transformation is its simplicity.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/polyconic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polyconic-1.1.0
+  title: Polyconic projection.
+  description: |-
+    Corresponds to the `PCO` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/polynomial-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polynomial-1.1.0
+  title: A Polynomial model.
+  description: |-
+    A polynomial model represented by its coefficients stored in
+    an ndarray of shape $(n+1)$ for univariate polynomials or $(n+1, n+1)$
+    for polynomials with 2 variables, where $n$ is the highest total degree
+    of the polynomial.
+
+    $$P = \sum_{i, j=0}^{i+j=n}c_{ij} * x^{i} * y^{j}$$
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/power-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/power-1.1.0
+  title: Perform a list of subtransforms in parallel and then raise each result to
+    the power of the next.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/quad_spherical_cube-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/quad_spherical_cube-1.1.0
+  title: Quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `QSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/regions_selector-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/regions_selector-1.1.0
+  title: Represents a discontinuous transform.
+  description: |-
+    Maps regions to transgorms and evaluates the transforms with the corresponding inputs.
+- tag_uri: tag:stsci.edu:asdf/transform/remap_axes-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/remap_axes-1.1.0
+  title: Reorder, add and drop axes.
+  description: |-
+    This transform allows the order of the input axes to be shuffled and
+    returned as the output axes.
+
+    It is a list made up of integers or "constant markers".  Each item
+    in the list corresponds to an output axis.  For each item:
+
+    - If an integer, it is the index of the input axis to send to the
+      output axis.
+
+    - If a constant, it must be a single item which is a constant value
+      to send to the output axis.
+
+    If only a list is provided, the number of input axes is
+    automatically determined from the maximum index in the list.  If an
+    object with `mapping` and `n_inputs` properties is provided, the
+    number of input axes is explicitly set by the `n_inputs` value.
+
+    Invertibility: TBD
+- tag_uri: tag:stsci.edu:asdf/transform/rotate2d-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate2d-1.1.0
+  title: A 2D rotation.
+  description: |-
+    A 2D rotation around the origin, in degrees.
+    Invertibility: All ASDF tools are required to be able to compute the analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/rotate3d-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate3d-1.1.0
+  title: Rotation in 3D space.
+  description: |-
+    Euler angle rotation around 3 axes.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/sanson_flamsteed-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/sanson_flamsteed-1.1.0
+  title: The Sanson-Flamsteed projection.
+  description: |-
+    Corresponds to the `SFL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\cos y} \\
+      \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \cos \theta \\
+      y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/scale-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/scale-1.1.0
+  title: A Scale model.
+  description: |-
+    Multiply the input by a factor.
+- tag_uri: tag:stsci.edu:asdf/transform/shift-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/shift-1.1.0
+  title: A Shift opeartion.
+  description: |-
+    Apply an offset in one direction.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_orthographic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_orthographic-1.1.0
+  title: The slant orthographic projection.
+  description: |-
+    Corresponds to the `SIN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \cos^{-1}\left(\frac{\pi}{180^{\circ}}R_\theta\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cos \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_zenithal_perspective-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_zenithal_perspective-1.1.0
+  title: The slant zenithal perspective projection.
+  description: |-
+    Corresponds to the `SZP` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:http://stsci.edu/schemas/asdf/transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/stereographic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/stereographic-1.1.0
+  title: The stereographic projection.
+  description: |-
+    Corresponds to the `STG` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^{\circ} - 2 \tan^{-1}\left(\frac{\pi R_\theta}{360^{\circ}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\frac{2 \cos \theta}{1 + \sin \theta}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/subtract-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/subtract-1.1.0
+  title: Perform a list of subtransforms in parallel and then subtract their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/tabular-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tabular-1.1.0
+  title: A Tabular model.
+  description: |-
+    Tabular represents a lookup table with values corresponding to
+    some grid points.
+    It computes the interpolated values corresponding to the given
+    inputs. Three methods of interpolation are supported -
+    "linear", "nearest" and "splinef2d". It supports extrapolation.
+- tag_uri: tag:stsci.edu:asdf/transform/tangential_spherical_cube-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tangential_spherical_cube-1.1.0
+  title: Tangential spherical cube projection.
+  description: |-
+    Corresponds to the `TSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equal_area-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equal_area-1.1.0
+  title: The zenithal equal area projection.
+  description: |-
+    Corresponds to the `ZEA` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - 2 \sin^{-1} \left(\frac{\pi R_\theta}{360^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta &= \frac{180^\circ}{\pi} \sqrt{2(1 - \sin\theta)} \\
+               &= \frac{360^\circ}{\pi} \sin\left(\frac{90^\circ - \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equidistant-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equidistant-1.1.0
+  title: The zenithal equidistant projection.
+  description: |-
+    Corresponds to the `ARC` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - R_\theta$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = 90^\circ - \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_perspective-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_perspective-1.1.0
+  title: The zenithal perspective projection.
+  description: |-
+    Corresponds to the `AZP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \arg(-y \cos \gamma, x) \\
+    \theta &= \left\{\genfrac{}{}{0pt}{}{\psi - \omega}{\psi + \omega + 180^{\circ}}\right.$$
+
+    where:
+
+    $$\psi &= \arg(\rho, 1) \\
+    \omega &= \sin^{-1}\left(\frac{\rho \mu}{\sqrt{\rho^2 + 1}}\right) \\
+    \rho &= \frac{R}{\frac{180^{\circ}}{\pi}(\mu + 1) + y \sin \gamma} \\
+    R &= \sqrt{x^2 + y^2 \cos^2 \gamma}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R \sin \phi \\
+    y &= -R \sec \gamma \cos \theta$$
+
+    where:
+
+    $$R = \frac{180^{\circ}}{\pi} \frac{(\mu + 1) \cos \theta}{(\mu + \sin \theta) + \cos \theta \cos \phi \tan \gamma}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.

--- a/resources/stsci.edu/manifests/transform-1.2.0.yaml
+++ b/resources/stsci.edu/manifests/transform-1.2.0.yaml
@@ -1,0 +1,675 @@
+id: http://stsci.edu/asdf/extensions/transform/manifests/transform-1.2.0
+extension_uri: http://stsci.edu/asdf/extensions/transform-1.2.0
+title: Transform extension 1.2.0
+description: |-
+  A set of tags for serializing data transforms.
+asdf_standard_requirement: 1.2.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/transform/add-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.1.0
+  title: Perform a list of subtransforms in parallel and then add their results together.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+- tag_uri: tag:stsci.edu:asdf/transform/affine-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/affine-1.2.0
+  title: An affine transform.
+  description: |-
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/airy-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/airy-1.2.0
+  title: The Airy projection.
+  description: |-
+    Corresponds to the `AIR` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+- tag_uri: tag:stsci.edu:asdf/transform/bonne_equal_area-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/bonne_equal_area-1.2.0
+  title: Bonne's equal area pseudoconic projection.
+  description: |-
+    Corresponds to the `BON` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi}{180^\circ} A_\phi R_\theta / \cos \theta \\
+      \theta &= Y_0 - R_\theta$$
+
+    where:
+
+    $$R_\theta &= \mathrm{sign} \theta_1 \sqrt{x^2 + (Y_0 - y)^2} \\
+      A_\phi &= \arg\left(\frac{Y_0 - y}{R_\theta}, \frac{x}{R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R_\theta \sin A_\phi \\
+      y &= -R_\theta \cos A_\phi + Y_0$$
+
+    where:
+
+    $$A_\phi &= \frac{180^\circ}{\pi R_\theta} \phi \cos \theta \\
+      R_\theta &= Y_0 - \theta \\
+      Y_0 &= \frac{180^\circ}{\pi} \cot \theta_1 + \theta_1$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/cobe_quad_spherical_cube-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cobe_quad_spherical_cube-1.1.0
+  title: COBE quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `CSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/compose-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/compose-1.1.0
+  title: Perform a list of subtransforms in series.
+  description: |-
+    The output of each subtransform is fed into the input of the next
+    subtransform.
+
+    The number of output dimensions of each subtransform must be equal
+    to the number of input dimensions of the next subtransform in list.
+    To reorder or add/drop axes, insert `remap_axes` transforms in the
+    subtransform list.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform, by reversing the list of
+    transforms and applying the inverse of each.
+- tag_uri: tag:stsci.edu:asdf/transform/concatenate-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/concatenate-1.1.0
+  title: Send axes to different subtransforms.
+  description: |-
+    Transforms a set of separable inputs by splitting the axes apart,
+    sending them through the given subtransforms in parallel, and
+    finally concatenating the subtransform output axes back together.
+
+    The input axes are assigned to each subtransform in order.  If the
+    number of input axes is unequal to the sum of the number of input
+    axes of all of the subtransforms, that is considered an error case.
+
+    The output axes from each subtransform are appended together to make
+    up the resulting output axes.
+
+    For example, given 5 input axes, and 3 subtransforms with the
+    following orders:
+
+    1. transform A: 2 in -> 2 out
+    1. transform B: 1 in -> 2 out
+    1. transform C: 2 in -> 1 out
+
+    The transform is performed as follows:
+
+    ```
+      :    i0    i1       i2       i3    i4
+      :    |     |        |        |     |
+      :  +---------+ +---------+ +----------+
+      :  |    A    | |    B    | |    C     |
+      :  +---------+ +---------+ +----------+
+      :    |     |     |     |        |
+      :    o0    o1    o2    o3       o4
+    ```
+
+    If reordering of the input or output axes is required, use in series
+    with the `remap_axes` transform.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equal_area-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equal_area-1.2.0
+  title: Alber's conic equal area projection.
+  description: |-
+    Corresponds to the `COE` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.2.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \gamma / 2 \\
+      R_\theta &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin \theta} \\
+      Y_0 &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin((\theta_1 + \theta_2)/2)}$$
+
+    where:
+
+    $$\gamma = \sin \theta_1 + \sin \theta_2$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equidistant-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equidistant-1.2.0
+  title: Conic equidistant projection.
+  description: |-
+    Corresponds to the `COD` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.2.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{180^\circ}{\pi} \frac{\sin\theta_a\sin\eta}{\eta} \\
+      R_\theta &= \theta_a - \theta + \eta\cot\eta\cot\theta_a \\
+      Y_0 = \eta\cot\eta\cot\theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_orthomorphic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_orthomorphic-1.2.0
+  title: Conic orthomorphic projection.
+  description: |-
+    Corresponds to the `COO` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.2.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{\ln \left( \frac{\cos\theta_2}{\cos\theta_1} \right)}
+                {\ln \left[ \frac{\tan\left(\frac{90^\circ-\theta_2}{2}\right)}
+                                 {\tan\left(\frac{90^\circ-\theta_1}{2}\right)} \right] } \\
+      R_\theta &= \psi \left[ \tan \left( \frac{90^\circ - \theta}{2} \right) \right]^C \\
+      Y_0 &= \psi \left[ \tan \left( \frac{90^\circ - \theta_a}{2} \right) \right]^C$$
+
+    where:
+
+    $$\psi = \frac{180^\circ}{\pi} \frac{\cos \theta}
+             {C\left[\tan\left(\frac{90^\circ-\theta}{2}\right)\right]^C}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_perspective-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_perspective-1.2.0
+  title: Colles' conic perspecitve projection.
+  description: |-
+    Corresponds to the `COP` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.2.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \sin \theta_a \\
+      R_\theta &= \frac{180^\circ}{\pi} \cos \eta [ \cot \theta_a - \tan(\theta - \theta_a)] \\
+      Y_0 &= \frac{180^\circ}{\pi} \cos \eta \cot \theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/constant-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/constant-1.2.0
+  title: A transform that takes no inputs and always outputs a constant value.
+  description: |-
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform, which always outputs zero values.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_equal_area-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_equal_area-1.2.0
+  title: The cylindrical equal area projection.
+  description: |-
+    Corresponds to the `CEA` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= \sin^{-1}\left(\frac{\pi}{180^{\circ}}\lambda y\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\frac{\sin \theta}{\lambda}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_perspective-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_perspective-1.2.0
+  title: The cylindrical perspective projection.
+  description: |-
+    Corresponds to the `CYP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\lambda} \\
+    \theta &= \arg(1, \eta) + \sin{-1}\left(\frac{\eta \mu}{\sqrt{\eta^2 + 1}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \lambda \phi \\
+    y &= \frac{180^{\circ}}{\pi}\left(\frac{\mu + \lambda}{\mu + \cos \theta}\right)\sin \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/divide-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/divide-1.1.0
+  title: Perform a list of subtransforms in parallel and then divide their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/generic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/generic-1.1.0
+  title: A generic transform.
+  description: |-
+    This is used **entirely** for bootstrapping purposes so one can create composite models including transforms that haven't yet been written.  **IT WILL NOT BE IN THE FINAL VERSION OF THE SPEC**.
+- tag_uri: tag:stsci.edu:asdf/transform/gnomonic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/gnomonic-1.1.0
+  title: The gnomonic projection.
+  description: |-
+    Corresponds to the `TAN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/hammer_aitoff-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/hammer_aitoff-1.1.0
+  title: Hammer-Aitoff projection.
+  description: |-
+    Corresponds to the `AIT` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= 2 \arg \left(2Z^2 - 1, \frac{\pi}{180^\circ} \frac{Z}{2}x\right) \\
+      \theta &= \sin^{-1}\left(\frac{\pi}{180^\circ}yZ\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= 2 \gamma \cos \theta \sin \frac{\phi}{2} \\
+      y &= \gamma \sin \theta$$
+
+    where:
+
+    $$\gamma = \frac{180^\circ}{\pi} \sqrt{\frac{2}{1 + \cos \theta \cos(\phi / 2)}}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix-1.1.0
+  title: HEALPix projection.
+  description: |-
+    Corresponds to the `HPX` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix_polar-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix_polar-1.1.0
+  title: HEALPix polar, aka "butterfly", projection.
+  description: |-
+    Corresponds to the `XPH` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/identity-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/identity-1.1.0
+  title: The identity transform.
+  description: |-
+    Invertibility: The inverse of this transform is also the identity transform.
+- tag_uri: tag:stsci.edu:asdf/transform/label_mapper-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/label_mapper-1.1.0
+  title: Represents a mapping from a coordinate value to a label.
+  description: |-
+    A label mapper instance maps inputs to a label.  It is used together
+    with
+    [regions_selector](ref:transform/regions_selector-1.1.0). The
+    [label_mapper](ref:transform/label_mapper-1.1.0)
+    returns the label corresponding to given inputs. The
+    [regions_selector](ref:transform/regions_selector-1.1.0)
+    returns the transform corresponding to this label. This maps inputs
+    (e.g. pixels on a detector) to transforms uniquely.
+- tag_uri: tag:stsci.edu:asdf/transform/mercator-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/mercator-1.1.0
+  title: The Mercator projection.
+  description: |-
+    Corresponds to the `MER` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= 2 \tan^{-1}\left(e^{y \pi / 180^{\circ}}\right)-90^{\circ}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\ln \tan \left(\frac{90^{\circ} + \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/molleweide-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/molleweide-1.1.0
+  title: Molleweide's projection.
+  description: |-
+    Corresponds to the `MOL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi x}{2 \sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}} \\
+      \theta &= \sin^{-1}\left(\frac{1}{90^\circ}\sin^{-1}\left(\frac{\pi}{180^\circ}\frac{y}{\sqrt{2}}\right) + \frac{y}{180^\circ}\sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \frac{2 \sqrt{2}}{\pi} \phi \cos \gamma \\
+      y &= \sqrt{2} \frac{180^\circ}{\pi} \sin \gamma$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/multiply-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/multiply-1.1.0
+  title: Perform a list of subtransforms in parallel and then multiply their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/parabolic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/parabolic-1.1.0
+  title: Parabolic projection.
+  description: |-
+    Corresponds to the `PAR` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{180^\circ}{\pi} \frac{x}{1 - 4(y / 180^\circ)^2} \\
+      \theta &= 3 \sin^{-1}\left(\frac{y}{180^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \left(2\cos\frac{2\theta}{3} - 1\right) \\
+      y &= 180^\circ \sin \frac{\theta}{3}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/plate_carree-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/plate_carree-1.1.0
+  title: "The plate carr\xE9e projection."
+  description: |-
+    Corresponds to the `CAR` projection in the FITS WCS standard.
+
+    The main virtue of this transformation is its simplicity.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/polyconic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polyconic-1.1.0
+  title: Polyconic projection.
+  description: |-
+    Corresponds to the `PCO` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/polynomial-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polynomial-1.2.0
+  title: A Polynomial model.
+  description: |-
+    A polynomial model represented by its coefficients stored in
+    an ndarray of shape $(n+1)$ for univariate polynomials or $(n+1, n+1)$
+    for polynomials with 2 variables, where $n$ is the highest total degree
+    of the polynomial.
+
+    $$P = \sum_{i, j=0}^{i+j=n}c_{ij} * x^{i} * y^{j}$$
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/power-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/power-1.1.0
+  title: Perform a list of subtransforms in parallel and then raise each result to
+    the power of the next.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/quad_spherical_cube-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/quad_spherical_cube-1.1.0
+  title: Quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `QSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/regions_selector-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/regions_selector-1.1.0
+  title: Represents a discontinuous transform.
+  description: |-
+    Maps regions to transgorms and evaluates the transforms with the corresponding inputs.
+- tag_uri: tag:stsci.edu:asdf/transform/remap_axes-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/remap_axes-1.1.0
+  title: Reorder, add and drop axes.
+  description: |-
+    This transform allows the order of the input axes to be shuffled and
+    returned as the output axes.
+
+    It is a list made up of integers or "constant markers".  Each item
+    in the list corresponds to an output axis.  For each item:
+
+    - If an integer, it is the index of the input axis to send to the
+      output axis.
+
+    - If a constant, it must be a single item which is a constant value
+      to send to the output axis.
+
+    If only a list is provided, the number of input axes is
+    automatically determined from the maximum index in the list.  If an
+    object with `mapping` and `n_inputs` properties is provided, the
+    number of input axes is explicitly set by the `n_inputs` value.
+
+    Invertibility: TBD
+- tag_uri: tag:stsci.edu:asdf/transform/rotate2d-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate2d-1.2.0
+  title: A 2D rotation.
+  description: |-
+    A 2D rotation around the origin, in degrees.
+    Invertibility: All ASDF tools are required to be able to compute the analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/rotate3d-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate3d-1.2.0
+  title: Rotation in 3D space.
+  description: |-
+    Euler angle rotation around 3 axes.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/sanson_flamsteed-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/sanson_flamsteed-1.1.0
+  title: The Sanson-Flamsteed projection.
+  description: |-
+    Corresponds to the `SFL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\cos y} \\
+      \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \cos \theta \\
+      y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/scale-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/scale-1.2.0
+  title: A Scale model.
+  description: |-
+    Scale the input by a dimensionless factor.
+- tag_uri: tag:stsci.edu:asdf/transform/shift-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/shift-1.2.0
+  title: A Shift opeartion.
+  description: |-
+    Apply an offset in one direction.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_orthographic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_orthographic-1.1.0
+  title: The slant orthographic projection.
+  description: |-
+    Corresponds to the `SIN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \cos^{-1}\left(\frac{\pi}{180^{\circ}}R_\theta\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cos \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_zenithal_perspective-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_zenithal_perspective-1.2.0
+  title: The slant zenithal perspective projection.
+  description: |-
+    Corresponds to the `SZP` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/stereographic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/stereographic-1.1.0
+  title: The stereographic projection.
+  description: |-
+    Corresponds to the `STG` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^{\circ} - 2 \tan^{-1}\left(\frac{\pi R_\theta}{360^{\circ}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\frac{2 \cos \theta}{1 + \sin \theta}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/subtract-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/subtract-1.1.0
+  title: Perform a list of subtransforms in parallel and then subtract their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/tabular-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tabular-1.2.0
+  title: A Tabular model.
+  description: |-
+    Tabular represents a lookup table with values corresponding to
+    some grid points.
+    It computes the interpolated values corresponding to the given
+    inputs. Three methods of interpolation are supported -
+    "linear", "nearest" and "splinef2d". It supports extrapolation.
+- tag_uri: tag:stsci.edu:asdf/transform/tangential_spherical_cube-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tangential_spherical_cube-1.1.0
+  title: Tangential spherical cube projection.
+  description: |-
+    Corresponds to the `TSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equal_area-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equal_area-1.1.0
+  title: The zenithal equal area projection.
+  description: |-
+    Corresponds to the `ZEA` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - 2 \sin^{-1} \left(\frac{\pi R_\theta}{360^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta &= \frac{180^\circ}{\pi} \sqrt{2(1 - \sin\theta)} \\
+               &= \frac{360^\circ}{\pi} \sin\left(\frac{90^\circ - \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equidistant-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equidistant-1.1.0
+  title: The zenithal equidistant projection.
+  description: |-
+    Corresponds to the `ARC` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - R_\theta$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = 90^\circ - \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_perspective-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_perspective-1.2.0
+  title: The zenithal perspective projection.
+  description: |-
+    Corresponds to the `AZP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \arg(-y \cos \gamma, x) \\
+    \theta &= \left\{\genfrac{}{}{0pt}{}{\psi - \omega}{\psi + \omega + 180^{\circ}}\right.$$
+
+    where:
+
+    $$\psi &= \arg(\rho, 1) \\
+    \omega &= \sin^{-1}\left(\frac{\rho \mu}{\sqrt{\rho^2 + 1}}\right) \\
+    \rho &= \frac{R}{\frac{180^{\circ}}{\pi}(\mu + 1) + y \sin \gamma} \\
+    R &= \sqrt{x^2 + y^2 \cos^2 \gamma}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R \sin \phi \\
+    y &= -R \sec \gamma \cos \theta$$
+
+    where:
+
+    $$R = \frac{180^{\circ}}{\pi} \frac{(\mu + 1) \cos \theta}{(\mu + \sin \theta) + \cos \theta \cos \phi \tan \gamma}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.

--- a/resources/stsci.edu/manifests/transform-1.3.0.yaml
+++ b/resources/stsci.edu/manifests/transform-1.3.0.yaml
@@ -1,0 +1,675 @@
+id: http://stsci.edu/asdf/extensions/transform/manifests/transform-1.3.0
+extension_uri: http://stsci.edu/asdf/extensions/transform-1.3.0
+title: Transform extension 1.3.0
+description: |-
+  A set of tags for serializing data transforms.
+asdf_standard_requirement: 1.3.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/transform/add-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.1.0
+  title: Perform a list of subtransforms in parallel and then add their results together.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+- tag_uri: tag:stsci.edu:asdf/transform/affine-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/affine-1.2.0
+  title: An affine transform.
+  description: |-
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/airy-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/airy-1.2.0
+  title: The Airy projection.
+  description: |-
+    Corresponds to the `AIR` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+- tag_uri: tag:stsci.edu:asdf/transform/bonne_equal_area-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/bonne_equal_area-1.2.0
+  title: Bonne's equal area pseudoconic projection.
+  description: |-
+    Corresponds to the `BON` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi}{180^\circ} A_\phi R_\theta / \cos \theta \\
+      \theta &= Y_0 - R_\theta$$
+
+    where:
+
+    $$R_\theta &= \mathrm{sign} \theta_1 \sqrt{x^2 + (Y_0 - y)^2} \\
+      A_\phi &= \arg\left(\frac{Y_0 - y}{R_\theta}, \frac{x}{R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R_\theta \sin A_\phi \\
+      y &= -R_\theta \cos A_\phi + Y_0$$
+
+    where:
+
+    $$A_\phi &= \frac{180^\circ}{\pi R_\theta} \phi \cos \theta \\
+      R_\theta &= Y_0 - \theta \\
+      Y_0 &= \frac{180^\circ}{\pi} \cot \theta_1 + \theta_1$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/cobe_quad_spherical_cube-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cobe_quad_spherical_cube-1.1.0
+  title: COBE quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `CSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/compose-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/compose-1.1.0
+  title: Perform a list of subtransforms in series.
+  description: |-
+    The output of each subtransform is fed into the input of the next
+    subtransform.
+
+    The number of output dimensions of each subtransform must be equal
+    to the number of input dimensions of the next subtransform in list.
+    To reorder or add/drop axes, insert `remap_axes` transforms in the
+    subtransform list.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform, by reversing the list of
+    transforms and applying the inverse of each.
+- tag_uri: tag:stsci.edu:asdf/transform/concatenate-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/concatenate-1.1.0
+  title: Send axes to different subtransforms.
+  description: |-
+    Transforms a set of separable inputs by splitting the axes apart,
+    sending them through the given subtransforms in parallel, and
+    finally concatenating the subtransform output axes back together.
+
+    The input axes are assigned to each subtransform in order.  If the
+    number of input axes is unequal to the sum of the number of input
+    axes of all of the subtransforms, that is considered an error case.
+
+    The output axes from each subtransform are appended together to make
+    up the resulting output axes.
+
+    For example, given 5 input axes, and 3 subtransforms with the
+    following orders:
+
+    1. transform A: 2 in -> 2 out
+    1. transform B: 1 in -> 2 out
+    1. transform C: 2 in -> 1 out
+
+    The transform is performed as follows:
+
+    ```
+      :    i0    i1       i2       i3    i4
+      :    |     |        |        |     |
+      :  +---------+ +---------+ +----------+
+      :  |    A    | |    B    | |    C     |
+      :  +---------+ +---------+ +----------+
+      :    |     |     |     |        |
+      :    o0    o1    o2    o3       o4
+    ```
+
+    If reordering of the input or output axes is required, use in series
+    with the `remap_axes` transform.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equal_area-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equal_area-1.2.0
+  title: Alber's conic equal area projection.
+  description: |-
+    Corresponds to the `COE` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.2.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \gamma / 2 \\
+      R_\theta &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin \theta} \\
+      Y_0 &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin((\theta_1 + \theta_2)/2)}$$
+
+    where:
+
+    $$\gamma = \sin \theta_1 + \sin \theta_2$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equidistant-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equidistant-1.2.0
+  title: Conic equidistant projection.
+  description: |-
+    Corresponds to the `COD` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.2.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{180^\circ}{\pi} \frac{\sin\theta_a\sin\eta}{\eta} \\
+      R_\theta &= \theta_a - \theta + \eta\cot\eta\cot\theta_a \\
+      Y_0 = \eta\cot\eta\cot\theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_orthomorphic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_orthomorphic-1.2.0
+  title: Conic orthomorphic projection.
+  description: |-
+    Corresponds to the `COO` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.2.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{\ln \left( \frac{\cos\theta_2}{\cos\theta_1} \right)}
+                {\ln \left[ \frac{\tan\left(\frac{90^\circ-\theta_2}{2}\right)}
+                                 {\tan\left(\frac{90^\circ-\theta_1}{2}\right)} \right] } \\
+      R_\theta &= \psi \left[ \tan \left( \frac{90^\circ - \theta}{2} \right) \right]^C \\
+      Y_0 &= \psi \left[ \tan \left( \frac{90^\circ - \theta_a}{2} \right) \right]^C$$
+
+    where:
+
+    $$\psi = \frac{180^\circ}{\pi} \frac{\cos \theta}
+             {C\left[\tan\left(\frac{90^\circ-\theta}{2}\right)\right]^C}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_perspective-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_perspective-1.2.0
+  title: Colles' conic perspecitve projection.
+  description: |-
+    Corresponds to the `COP` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.2.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \sin \theta_a \\
+      R_\theta &= \frac{180^\circ}{\pi} \cos \eta [ \cot \theta_a - \tan(\theta - \theta_a)] \\
+      Y_0 &= \frac{180^\circ}{\pi} \cos \eta \cot \theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/constant-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/constant-1.2.0
+  title: A transform that takes no inputs and always outputs a constant value.
+  description: |-
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform, which always outputs zero values.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_equal_area-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_equal_area-1.2.0
+  title: The cylindrical equal area projection.
+  description: |-
+    Corresponds to the `CEA` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= \sin^{-1}\left(\frac{\pi}{180^{\circ}}\lambda y\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\frac{\sin \theta}{\lambda}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_perspective-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_perspective-1.2.0
+  title: The cylindrical perspective projection.
+  description: |-
+    Corresponds to the `CYP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\lambda} \\
+    \theta &= \arg(1, \eta) + \sin{-1}\left(\frac{\eta \mu}{\sqrt{\eta^2 + 1}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \lambda \phi \\
+    y &= \frac{180^{\circ}}{\pi}\left(\frac{\mu + \lambda}{\mu + \cos \theta}\right)\sin \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/divide-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/divide-1.1.0
+  title: Perform a list of subtransforms in parallel and then divide their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/generic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/generic-1.1.0
+  title: A generic transform.
+  description: |-
+    This is used **entirely** for bootstrapping purposes so one can create composite models including transforms that haven't yet been written.  **IT WILL NOT BE IN THE FINAL VERSION OF THE SPEC**.
+- tag_uri: tag:stsci.edu:asdf/transform/gnomonic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/gnomonic-1.1.0
+  title: The gnomonic projection.
+  description: |-
+    Corresponds to the `TAN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/hammer_aitoff-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/hammer_aitoff-1.1.0
+  title: Hammer-Aitoff projection.
+  description: |-
+    Corresponds to the `AIT` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= 2 \arg \left(2Z^2 - 1, \frac{\pi}{180^\circ} \frac{Z}{2}x\right) \\
+      \theta &= \sin^{-1}\left(\frac{\pi}{180^\circ}yZ\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= 2 \gamma \cos \theta \sin \frac{\phi}{2} \\
+      y &= \gamma \sin \theta$$
+
+    where:
+
+    $$\gamma = \frac{180^\circ}{\pi} \sqrt{\frac{2}{1 + \cos \theta \cos(\phi / 2)}}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix-1.1.0
+  title: HEALPix projection.
+  description: |-
+    Corresponds to the `HPX` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix_polar-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix_polar-1.1.0
+  title: HEALPix polar, aka "butterfly", projection.
+  description: |-
+    Corresponds to the `XPH` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/identity-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/identity-1.1.0
+  title: The identity transform.
+  description: |-
+    Invertibility: The inverse of this transform is also the identity transform.
+- tag_uri: tag:stsci.edu:asdf/transform/label_mapper-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/label_mapper-1.1.0
+  title: Represents a mapping from a coordinate value to a label.
+  description: |-
+    A label mapper instance maps inputs to a label.  It is used together
+    with
+    [regions_selector](ref:transform/regions_selector-1.1.0). The
+    [label_mapper](ref:transform/label_mapper-1.1.0)
+    returns the label corresponding to given inputs. The
+    [regions_selector](ref:transform/regions_selector-1.1.0)
+    returns the transform corresponding to this label. This maps inputs
+    (e.g. pixels on a detector) to transforms uniquely.
+- tag_uri: tag:stsci.edu:asdf/transform/mercator-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/mercator-1.1.0
+  title: The Mercator projection.
+  description: |-
+    Corresponds to the `MER` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= 2 \tan^{-1}\left(e^{y \pi / 180^{\circ}}\right)-90^{\circ}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\ln \tan \left(\frac{90^{\circ} + \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/molleweide-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/molleweide-1.1.0
+  title: Molleweide's projection.
+  description: |-
+    Corresponds to the `MOL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi x}{2 \sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}} \\
+      \theta &= \sin^{-1}\left(\frac{1}{90^\circ}\sin^{-1}\left(\frac{\pi}{180^\circ}\frac{y}{\sqrt{2}}\right) + \frac{y}{180^\circ}\sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \frac{2 \sqrt{2}}{\pi} \phi \cos \gamma \\
+      y &= \sqrt{2} \frac{180^\circ}{\pi} \sin \gamma$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/multiply-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/multiply-1.1.0
+  title: Perform a list of subtransforms in parallel and then multiply their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/parabolic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/parabolic-1.1.0
+  title: Parabolic projection.
+  description: |-
+    Corresponds to the `PAR` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{180^\circ}{\pi} \frac{x}{1 - 4(y / 180^\circ)^2} \\
+      \theta &= 3 \sin^{-1}\left(\frac{y}{180^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \left(2\cos\frac{2\theta}{3} - 1\right) \\
+      y &= 180^\circ \sin \frac{\theta}{3}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/plate_carree-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/plate_carree-1.1.0
+  title: "The plate carr\xE9e projection."
+  description: |-
+    Corresponds to the `CAR` projection in the FITS WCS standard.
+
+    The main virtue of this transformation is its simplicity.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/polyconic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polyconic-1.1.0
+  title: Polyconic projection.
+  description: |-
+    Corresponds to the `PCO` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/polynomial-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polynomial-1.2.0
+  title: A Polynomial model.
+  description: |-
+    A polynomial model represented by its coefficients stored in
+    an ndarray of shape $(n+1)$ for univariate polynomials or $(n+1, n+1)$
+    for polynomials with 2 variables, where $n$ is the highest total degree
+    of the polynomial.
+
+    $$P = \sum_{i, j=0}^{i+j=n}c_{ij} * x^{i} * y^{j}$$
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/power-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/power-1.1.0
+  title: Perform a list of subtransforms in parallel and then raise each result to
+    the power of the next.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/quad_spherical_cube-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/quad_spherical_cube-1.1.0
+  title: Quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `QSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/regions_selector-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/regions_selector-1.1.0
+  title: Represents a discontinuous transform.
+  description: |-
+    Maps regions to transgorms and evaluates the transforms with the corresponding inputs.
+- tag_uri: tag:stsci.edu:asdf/transform/remap_axes-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/remap_axes-1.1.0
+  title: Reorder, add and drop axes.
+  description: |-
+    This transform allows the order of the input axes to be shuffled and
+    returned as the output axes.
+
+    It is a list made up of integers or "constant markers".  Each item
+    in the list corresponds to an output axis.  For each item:
+
+    - If an integer, it is the index of the input axis to send to the
+      output axis.
+
+    - If a constant, it must be a single item which is a constant value
+      to send to the output axis.
+
+    If only a list is provided, the number of input axes is
+    automatically determined from the maximum index in the list.  If an
+    object with `mapping` and `n_inputs` properties is provided, the
+    number of input axes is explicitly set by the `n_inputs` value.
+
+    Invertibility: TBD
+- tag_uri: tag:stsci.edu:asdf/transform/rotate2d-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate2d-1.2.0
+  title: A 2D rotation.
+  description: |-
+    A 2D rotation around the origin, in degrees.
+    Invertibility: All ASDF tools are required to be able to compute the analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/rotate3d-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate3d-1.2.0
+  title: Rotation in 3D space.
+  description: |-
+    Euler angle rotation around 3 axes.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/sanson_flamsteed-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/sanson_flamsteed-1.1.0
+  title: The Sanson-Flamsteed projection.
+  description: |-
+    Corresponds to the `SFL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\cos y} \\
+      \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \cos \theta \\
+      y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/scale-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/scale-1.2.0
+  title: A Scale model.
+  description: |-
+    Scale the input by a dimensionless factor.
+- tag_uri: tag:stsci.edu:asdf/transform/shift-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/shift-1.2.0
+  title: A Shift opeartion.
+  description: |-
+    Apply an offset in one direction.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_orthographic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_orthographic-1.1.0
+  title: The slant orthographic projection.
+  description: |-
+    Corresponds to the `SIN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \cos^{-1}\left(\frac{\pi}{180^{\circ}}R_\theta\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cos \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_zenithal_perspective-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_zenithal_perspective-1.2.0
+  title: The slant zenithal perspective projection.
+  description: |-
+    Corresponds to the `SZP` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/stereographic-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/stereographic-1.1.0
+  title: The stereographic projection.
+  description: |-
+    Corresponds to the `STG` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^{\circ} - 2 \tan^{-1}\left(\frac{\pi R_\theta}{360^{\circ}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\frac{2 \cos \theta}{1 + \sin \theta}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/subtract-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/subtract-1.1.0
+  title: Perform a list of subtransforms in parallel and then subtract their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/tabular-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tabular-1.2.0
+  title: A Tabular model.
+  description: |-
+    Tabular represents a lookup table with values corresponding to
+    some grid points.
+    It computes the interpolated values corresponding to the given
+    inputs. Three methods of interpolation are supported -
+    "linear", "nearest" and "splinef2d". It supports extrapolation.
+- tag_uri: tag:stsci.edu:asdf/transform/tangential_spherical_cube-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tangential_spherical_cube-1.1.0
+  title: Tangential spherical cube projection.
+  description: |-
+    Corresponds to the `TSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equal_area-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equal_area-1.1.0
+  title: The zenithal equal area projection.
+  description: |-
+    Corresponds to the `ZEA` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - 2 \sin^{-1} \left(\frac{\pi R_\theta}{360^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta &= \frac{180^\circ}{\pi} \sqrt{2(1 - \sin\theta)} \\
+               &= \frac{360^\circ}{\pi} \sin\left(\frac{90^\circ - \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equidistant-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equidistant-1.1.0
+  title: The zenithal equidistant projection.
+  description: |-
+    Corresponds to the `ARC` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.1.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - R_\theta$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = 90^\circ - \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_perspective-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_perspective-1.2.0
+  title: The zenithal perspective projection.
+  description: |-
+    Corresponds to the `AZP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \arg(-y \cos \gamma, x) \\
+    \theta &= \left\{\genfrac{}{}{0pt}{}{\psi - \omega}{\psi + \omega + 180^{\circ}}\right.$$
+
+    where:
+
+    $$\psi &= \arg(\rho, 1) \\
+    \omega &= \sin^{-1}\left(\frac{\rho \mu}{\sqrt{\rho^2 + 1}}\right) \\
+    \rho &= \frac{R}{\frac{180^{\circ}}{\pi}(\mu + 1) + y \sin \gamma} \\
+    R &= \sqrt{x^2 + y^2 \cos^2 \gamma}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R \sin \phi \\
+    y &= -R \sec \gamma \cos \theta$$
+
+    where:
+
+    $$R = \frac{180^{\circ}}{\pi} \frac{(\mu + 1) \cos \theta}{(\mu + \sin \theta) + \cos \theta \cos \phi \tan \gamma}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.

--- a/resources/stsci.edu/manifests/transform-1.4.0.yaml
+++ b/resources/stsci.edu/manifests/transform-1.4.0.yaml
@@ -1,0 +1,721 @@
+id: http://stsci.edu/asdf/extensions/transform/manifests/transform-1.4.0
+extension_uri: http://stsci.edu/asdf/extensions/transform-1.4.0
+title: Transform extension 1.4.0
+description: |-
+  A set of tags for serializing data transforms.
+asdf_standard_requirement: 1.4.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/transform/add-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.2.0
+  title: Perform a list of subtransforms in parallel and then add their results together.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+- tag_uri: tag:stsci.edu:asdf/transform/affine-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/affine-1.3.0
+  title: An affine transform.
+  description: |-
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/airy-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/airy-1.2.0
+  title: The Airy projection.
+  description: |-
+    Corresponds to the `AIR` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+- tag_uri: tag:stsci.edu:asdf/transform/bonne_equal_area-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/bonne_equal_area-1.3.0
+  title: Bonne's equal area pseudoconic projection.
+  description: |-
+    Corresponds to the `BON` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi}{180^\circ} A_\phi R_\theta / \cos \theta \\
+      \theta &= Y_0 - R_\theta$$
+
+    where:
+
+    $$R_\theta &= \mathrm{sign} \theta_1 \sqrt{x^2 + (Y_0 - y)^2} \\
+      A_\phi &= \arg\left(\frac{Y_0 - y}{R_\theta}, \frac{x}{R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R_\theta \sin A_\phi \\
+      y &= -R_\theta \cos A_\phi + Y_0$$
+
+    where:
+
+    $$A_\phi &= \frac{180^\circ}{\pi R_\theta} \phi \cos \theta \\
+      R_\theta &= Y_0 - \theta \\
+      Y_0 &= \frac{180^\circ}{\pi} \cot \theta_1 + \theta_1$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/cobe_quad_spherical_cube-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cobe_quad_spherical_cube-1.2.0
+  title: COBE quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `CSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/compose-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/compose-1.2.0
+  title: Perform a list of subtransforms in series.
+  description: |-
+    The output of each subtransform is fed into the input of the next
+    subtransform.
+
+    The number of output dimensions of each subtransform must be equal
+    to the number of input dimensions of the next subtransform in list.
+    To reorder or add/drop axes, insert `remap_axes` transforms in the
+    subtransform list.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform, by reversing the list of
+    transforms and applying the inverse of each.
+- tag_uri: tag:stsci.edu:asdf/transform/concatenate-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/concatenate-1.2.0
+  title: Send axes to different subtransforms.
+  description: |-
+    Transforms a set of separable inputs by splitting the axes apart,
+    sending them through the given subtransforms in parallel, and
+    finally concatenating the subtransform output axes back together.
+
+    The input axes are assigned to each subtransform in order.  If the
+    number of input axes is unequal to the sum of the number of input
+    axes of all of the subtransforms, that is considered an error case.
+
+    The output axes from each subtransform are appended together to make
+    up the resulting output axes.
+
+    For example, given 5 input axes, and 3 subtransforms with the
+    following orders:
+
+    1. transform A: 2 in -> 2 out
+    1. transform B: 1 in -> 2 out
+    1. transform C: 2 in -> 1 out
+
+    The transform is performed as follows:
+
+    ```
+      :    i0    i1       i2       i3    i4
+      :    |     |        |        |     |
+      :  +---------+ +---------+ +----------+
+      :  |    A    | |    B    | |    C     |
+      :  +---------+ +---------+ +----------+
+      :    |     |     |     |        |
+      :    o0    o1    o2    o3       o4
+    ```
+
+    If reordering of the input or output axes is required, use in series
+    with the `remap_axes` transform.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equal_area-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equal_area-1.3.0
+  title: Alber's conic equal area projection.
+  description: |-
+    Corresponds to the `COE` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.3.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \gamma / 2 \\
+      R_\theta &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin \theta} \\
+      Y_0 &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin((\theta_1 + \theta_2)/2)}$$
+
+    where:
+
+    $$\gamma = \sin \theta_1 + \sin \theta_2$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equidistant-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equidistant-1.3.0
+  title: Conic equidistant projection.
+  description: |-
+    Corresponds to the `COD` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.3.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{180^\circ}{\pi} \frac{\sin\theta_a\sin\eta}{\eta} \\
+      R_\theta &= \theta_a - \theta + \eta\cot\eta\cot\theta_a \\
+      Y_0 = \eta\cot\eta\cot\theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_orthomorphic-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_orthomorphic-1.3.0
+  title: Conic orthomorphic projection.
+  description: |-
+    Corresponds to the `COO` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.3.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{\ln \left( \frac{\cos\theta_2}{\cos\theta_1} \right)}
+                {\ln \left[ \frac{\tan\left(\frac{90^\circ-\theta_2}{2}\right)}
+                                 {\tan\left(\frac{90^\circ-\theta_1}{2}\right)} \right] } \\
+      R_\theta &= \psi \left[ \tan \left( \frac{90^\circ - \theta}{2} \right) \right]^C \\
+      Y_0 &= \psi \left[ \tan \left( \frac{90^\circ - \theta_a}{2} \right) \right]^C$$
+
+    where:
+
+    $$\psi = \frac{180^\circ}{\pi} \frac{\cos \theta}
+             {C\left[\tan\left(\frac{90^\circ-\theta}{2}\right)\right]^C}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_perspective-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_perspective-1.3.0
+  title: Colles' conic perspecitve projection.
+  description: |-
+    Corresponds to the `COP` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.3.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \sin \theta_a \\
+      R_\theta &= \frac{180^\circ}{\pi} \cos \eta [ \cot \theta_a - \tan(\theta - \theta_a)] \\
+      Y_0 &= \frac{180^\circ}{\pi} \cos \eta \cot \theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/constant-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/constant-1.3.0
+  title: A transform that takes no inputs and always outputs a constant value.
+  description: |-
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform, which always outputs zero values.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_equal_area-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_equal_area-1.3.0
+  title: The cylindrical equal area projection.
+  description: |-
+    Corresponds to the `CEA` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= \sin^{-1}\left(\frac{\pi}{180^{\circ}}\lambda y\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\frac{\sin \theta}{\lambda}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_perspective-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_perspective-1.3.0
+  title: The cylindrical perspective projection.
+  description: |-
+    Corresponds to the `CYP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\lambda} \\
+    \theta &= \arg(1, \eta) + \sin{-1}\left(\frac{\eta \mu}{\sqrt{\eta^2 + 1}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \lambda \phi \\
+    y &= \frac{180^{\circ}}{\pi}\left(\frac{\mu + \lambda}{\mu + \cos \theta}\right)\sin \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/divide-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/divide-1.2.0
+  title: Perform a list of subtransforms in parallel and then divide their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/fix_inputs-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/fix_inputs-1.2.0
+  title: Set to a constant selected input arguments of a model.
+  description: |-
+    This operation takes as the right hand side a dict equivalent
+    that consists of key:value pairs where the key identifies
+    the input argument to be set, either by position number
+    (0 based) or name, and the value is the floating point value
+    that should be assigned to that input. The result is a
+    compound model with n fewer input arguments where n is
+    the number of input values to be set (i.e., the number
+    of keys in the dict).
+- tag_uri: tag:stsci.edu:asdf/transform/generic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/generic-1.2.0
+  title: A generic transform.
+  description: |-
+    This is used **entirely** for bootstrapping purposes so one can create composite models including transforms that haven't yet been written.  **IT WILL NOT BE IN THE FINAL VERSION OF THE SPEC**.
+- tag_uri: tag:stsci.edu:asdf/transform/gnomonic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/gnomonic-1.2.0
+  title: The gnomonic projection.
+  description: |-
+    Corresponds to the `TAN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/hammer_aitoff-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/hammer_aitoff-1.2.0
+  title: Hammer-Aitoff projection.
+  description: |-
+    Corresponds to the `AIT` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= 2 \arg \left(2Z^2 - 1, \frac{\pi}{180^\circ} \frac{Z}{2}x\right) \\
+      \theta &= \sin^{-1}\left(\frac{\pi}{180^\circ}yZ\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= 2 \gamma \cos \theta \sin \frac{\phi}{2} \\
+      y &= \gamma \sin \theta$$
+
+    where:
+
+    $$\gamma = \frac{180^\circ}{\pi} \sqrt{\frac{2}{1 + \cos \theta \cos(\phi / 2)}}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix-1.2.0
+  title: HEALPix projection.
+  description: |-
+    Corresponds to the `HPX` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix_polar-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix_polar-1.2.0
+  title: HEALPix polar, aka "butterfly", projection.
+  description: |-
+    Corresponds to the `XPH` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/identity-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/identity-1.2.0
+  title: The identity transform.
+  description: |-
+    Invertibility: The inverse of this transform is also the identity transform.
+- tag_uri: tag:stsci.edu:asdf/transform/label_mapper-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/label_mapper-1.2.0
+  title: Represents a mapping from a coordinate value to a label.
+  description: |-
+    A label mapper instance maps inputs to a label.  It is used together
+    with
+    [regions_selector](ref:transform/regions_selector-1.2.0). The
+    [label_mapper](ref:transform/label_mapper-1.2.0)
+    returns the label corresponding to given inputs. The
+    [regions_selector](ref:transform/regions_selector-1.2.0)
+    returns the transform corresponding to this label. This maps inputs
+    (e.g. pixels on a detector) to transforms uniquely.
+- tag_uri: tag:stsci.edu:asdf/transform/linear1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/linear1d-1.0.0
+  title: A one dimensional line model
+  description: |-
+    A one dimensional line model
+- tag_uri: tag:stsci.edu:asdf/transform/math_functions-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/math_functions-1.0.0
+  title: Math functions.
+  description: |-
+    Commonly used math funcitons.
+- tag_uri: tag:stsci.edu:asdf/transform/mercator-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/mercator-1.2.0
+  title: The Mercator projection.
+  description: |-
+    Corresponds to the `MER` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= 2 \tan^{-1}\left(e^{y \pi / 180^{\circ}}\right)-90^{\circ}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\ln \tan \left(\frac{90^{\circ} + \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/molleweide-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/molleweide-1.2.0
+  title: Molleweide's projection.
+  description: |-
+    Corresponds to the `MOL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi x}{2 \sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}} \\
+      \theta &= \sin^{-1}\left(\frac{1}{90^\circ}\sin^{-1}\left(\frac{\pi}{180^\circ}\frac{y}{\sqrt{2}}\right) + \frac{y}{180^\circ}\sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \frac{2 \sqrt{2}}{\pi} \phi \cos \gamma \\
+      y &= \sqrt{2} \frac{180^\circ}{\pi} \sin \gamma$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/multiply-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/multiply-1.2.0
+  title: Perform a list of subtransforms in parallel and then multiply their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/multiplyscale-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/multiplyscale-1.0.0
+  title: A Multiply model.
+  description: |-
+    Multiply the input by a factor.
+- tag_uri: tag:stsci.edu:asdf/transform/ortho_polynomial-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/ortho_polynomial-1.0.0
+  title: Respresents various Orthogonal Polynomial models.
+  description: |-
+    A polynomial model represented by its coefficients stored in
+    an ndarray of shape $(n+1)$ for univariate polynomials or $(n+1, n+1)$
+    for polynomials with 2 variables, where $n$ is the highest total degree
+    of the polynomial. The property polynomial_type defines what kind of
+    polynomial is defined.
+
+    $$P = \sum_{i, j=0}^{i+j=n}c_{ij} * x^{i} * y^{j}$$
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/parabolic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/parabolic-1.2.0
+  title: Parabolic projection.
+  description: |-
+    Corresponds to the `PAR` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{180^\circ}{\pi} \frac{x}{1 - 4(y / 180^\circ)^2} \\
+      \theta &= 3 \sin^{-1}\left(\frac{y}{180^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \left(2\cos\frac{2\theta}{3} - 1\right) \\
+      y &= 180^\circ \sin \frac{\theta}{3}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/plate_carree-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/plate_carree-1.2.0
+  title: "The plate carr\xE9e projection."
+  description: |-
+    Corresponds to the `CAR` projection in the FITS WCS standard.
+
+    The main virtue of this transformation is its simplicity.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/polyconic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polyconic-1.2.0
+  title: Polyconic projection.
+  description: |-
+    Corresponds to the `PCO` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/polynomial-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polynomial-1.2.0
+  title: A Polynomial model.
+  description: |-
+    A polynomial model represented by its coefficients stored in
+    an ndarray of shape $(n+1)$ for univariate polynomials or $(n+1, n+1)$
+    for polynomials with 2 variables, where $n$ is the highest total degree
+    of the polynomial.
+
+    $$P = \sum_{i, j=0}^{i+j=n}c_{ij} * x^{i} * y^{j}$$
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/power-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/power-1.2.0
+  title: Perform a list of subtransforms in parallel and then raise each result to
+    the power of the next.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/quad_spherical_cube-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/quad_spherical_cube-1.2.0
+  title: Quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `QSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/regions_selector-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/regions_selector-1.2.0
+  title: Represents a discontinuous transform.
+  description: |-
+    Maps regions to transgorms and evaluates the transforms with the corresponding inputs.
+- tag_uri: tag:stsci.edu:asdf/transform/remap_axes-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/remap_axes-1.2.0
+  title: Reorder, add and drop axes.
+  description: |-
+    This transform allows the order of the input axes to be shuffled and
+    returned as the output axes.
+
+    It is a list made up of integers or "constant markers".  Each item
+    in the list corresponds to an output axis.  For each item:
+
+    - If an integer, it is the index of the input axis to send to the
+      output axis.
+
+    - If a constant, it must be a single item which is a constant value
+      to send to the output axis.
+
+    If only a list is provided, the number of input axes is
+    automatically determined from the maximum index in the list.  If an
+    object with `mapping` and `n_inputs` properties is provided, the
+    number of input axes is explicitly set by the `n_inputs` value.
+
+    Invertibility: TBD
+- tag_uri: tag:stsci.edu:asdf/transform/rotate2d-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate2d-1.3.0
+  title: A 2D rotation.
+  description: |-
+    A 2D rotation around the origin, in degrees.
+    Invertibility: All ASDF tools are required to be able to compute the analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/rotate3d-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate3d-1.3.0
+  title: Rotation in 3D space.
+  description: |-
+    Euler angle rotation around 3 axes.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/rotate_sequence_3d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate_sequence_3d-1.0.0
+  title: Rotation in 3D space.
+  description: |-
+    Rotation in 3D space by arbitrary number of angles about
+    arbitrary order of "x", "y", "z" axes.
+- tag_uri: tag:stsci.edu:asdf/transform/sanson_flamsteed-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/sanson_flamsteed-1.2.0
+  title: The Sanson-Flamsteed projection.
+  description: |-
+    Corresponds to the `SFL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\cos y} \\
+      \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \cos \theta \\
+      y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/scale-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/scale-1.2.0
+  title: A Scale model.
+  description: |-
+    Scale the input by a dimensionless factor.
+- tag_uri: tag:stsci.edu:asdf/transform/shift-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/shift-1.2.0
+  title: A Shift opeartion.
+  description: |-
+    Apply an offset in one direction.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_orthographic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_orthographic-1.2.0
+  title: The slant orthographic projection.
+  description: |-
+    Corresponds to the `SIN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \cos^{-1}\left(\frac{\pi}{180^{\circ}}R_\theta\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cos \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_zenithal_perspective-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_zenithal_perspective-1.2.0
+  title: The slant zenithal perspective projection.
+  description: |-
+    Corresponds to the `SZP` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/stereographic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/stereographic-1.2.0
+  title: The stereographic projection.
+  description: |-
+    Corresponds to the `STG` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^{\circ} - 2 \tan^{-1}\left(\frac{\pi R_\theta}{360^{\circ}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\frac{2 \cos \theta}{1 + \sin \theta}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/subtract-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/subtract-1.2.0
+  title: Perform a list of subtransforms in parallel and then subtract their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/tabular-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tabular-1.2.0
+  title: A Tabular model.
+  description: |-
+    Tabular represents a lookup table with values corresponding to
+    some grid points.
+    It computes the interpolated values corresponding to the given
+    inputs. Three methods of interpolation are supported -
+    "linear", "nearest" and "splinef2d". It supports extrapolation.
+- tag_uri: tag:stsci.edu:asdf/transform/tangential_spherical_cube-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tangential_spherical_cube-1.2.0
+  title: Tangential spherical cube projection.
+  description: |-
+    Corresponds to the `TSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equal_area-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equal_area-1.2.0
+  title: The zenithal equal area projection.
+  description: |-
+    Corresponds to the `ZEA` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - 2 \sin^{-1} \left(\frac{\pi R_\theta}{360^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta &= \frac{180^\circ}{\pi} \sqrt{2(1 - \sin\theta)} \\
+               &= \frac{360^\circ}{\pi} \sin\left(\frac{90^\circ - \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equidistant-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equidistant-1.2.0
+  title: The zenithal equidistant projection.
+  description: |-
+    Corresponds to the `ARC` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - R_\theta$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = 90^\circ - \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_perspective-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_perspective-1.3.0
+  title: The zenithal perspective projection.
+  description: |-
+    Corresponds to the `AZP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \arg(-y \cos \gamma, x) \\
+    \theta &= \left\{\genfrac{}{}{0pt}{}{\psi - \omega}{\psi + \omega + 180^{\circ}}\right.$$
+
+    where:
+
+    $$\psi &= \arg(\rho, 1) \\
+    \omega &= \sin^{-1}\left(\frac{\rho \mu}{\sqrt{\rho^2 + 1}}\right) \\
+    \rho &= \frac{R}{\frac{180^{\circ}}{\pi}(\mu + 1) + y \sin \gamma} \\
+    R &= \sqrt{x^2 + y^2 \cos^2 \gamma}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R \sin \phi \\
+    y &= -R \sec \gamma \cos \theta$$
+
+    where:
+
+    $$R = \frac{180^{\circ}}{\pi} \frac{(\mu + 1) \cos \theta}{(\mu + \sin \theta) + \cos \theta \cos \phi \tan \gamma}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.

--- a/resources/stsci.edu/manifests/transform-1.5.0.yaml
+++ b/resources/stsci.edu/manifests/transform-1.5.0.yaml
@@ -1,0 +1,856 @@
+id: http://stsci.edu/asdf/extensions/transform/manifests/transform-1.5.0
+extension_uri: http://stsci.edu/asdf/extensions/transform-1.5.0
+title: Transform extension 1.5.0
+description: |-
+  A set of tags for serializing data transforms.
+asdf_standard_requirement: 1.5.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/transform/add-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.2.0
+  title: Perform a list of subtransforms in parallel and then add their results together.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+- tag_uri: tag:stsci.edu:asdf/transform/affine-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/affine-1.3.0
+  title: An affine transform.
+  description: |-
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/airy-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/airy-1.2.0
+  title: The Airy projection.
+  description: |-
+    Corresponds to the `AIR` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+- tag_uri: tag:stsci.edu:asdf/transform/airy_disk2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/airy_disk2d-1.0.0
+  title: Two dimensional Airy disk model.
+  description: |-
+    Two dimensional Airy disk model.
+- tag_uri: tag:stsci.edu:asdf/transform/blackbody-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/blackbody-1.0.0
+  title: Blackbody model.
+  description: |-
+    Blackbody model using the Planck function.
+
+    $$B_{\\nu}(T) = A \frac{2 h \nu^{3} / c^{2}}{exp(h \nu / k T) - 1}$$
+- tag_uri: tag:stsci.edu:asdf/transform/bonne_equal_area-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/bonne_equal_area-1.3.0
+  title: Bonne's equal area pseudoconic projection.
+  description: |-
+    Corresponds to the `BON` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi}{180^\circ} A_\phi R_\theta / \cos \theta \\
+      \theta &= Y_0 - R_\theta$$
+
+    where:
+
+    $$R_\theta &= \mathrm{sign} \theta_1 \sqrt{x^2 + (Y_0 - y)^2} \\
+      A_\phi &= \arg\left(\frac{Y_0 - y}{R_\theta}, \frac{x}{R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R_\theta \sin A_\phi \\
+      y &= -R_\theta \cos A_\phi + Y_0$$
+
+    where:
+
+    $$A_\phi &= \frac{180^\circ}{\pi R_\theta} \phi \cos \theta \\
+      R_\theta &= Y_0 - \theta \\
+      Y_0 &= \frac{180^\circ}{\pi} \cot \theta_1 + \theta_1$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/box1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/box1d-1.0.0
+  title: One dimensional box model.
+  description: |-
+    One dimensional box.
+- tag_uri: tag:stsci.edu:asdf/transform/box2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/box2d-1.0.0
+  title: Two dimensional box model.
+  description: |-
+    Two dimensional box.
+- tag_uri: tag:stsci.edu:asdf/transform/broken_power_law1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/broken_power_law1d-1.0.0
+  title: One dimensional power law model with a break.
+  description: |-
+    One dimensional power law model with a break.
+- tag_uri: tag:stsci.edu:asdf/transform/cobe_quad_spherical_cube-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cobe_quad_spherical_cube-1.2.0
+  title: COBE quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `CSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/compose-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/compose-1.2.0
+  title: Perform a list of subtransforms in series.
+  description: |-
+    The output of each subtransform is fed into the input of the next
+    subtransform.
+
+    The number of output dimensions of each subtransform must be equal
+    to the number of input dimensions of the next subtransform in list.
+    To reorder or add/drop axes, insert `remap_axes` transforms in the
+    subtransform list.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform, by reversing the list of
+    transforms and applying the inverse of each.
+- tag_uri: tag:stsci.edu:asdf/transform/concatenate-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/concatenate-1.2.0
+  title: Send axes to different subtransforms.
+  description: |-
+    Transforms a set of separable inputs by splitting the axes apart,
+    sending them through the given subtransforms in parallel, and
+    finally concatenating the subtransform output axes back together.
+
+    The input axes are assigned to each subtransform in order.  If the
+    number of input axes is unequal to the sum of the number of input
+    axes of all of the subtransforms, that is considered an error case.
+
+    The output axes from each subtransform are appended together to make
+    up the resulting output axes.
+
+    For example, given 5 input axes, and 3 subtransforms with the
+    following orders:
+
+    1. transform A: 2 in -> 2 out
+    1. transform B: 1 in -> 2 out
+    1. transform C: 2 in -> 1 out
+
+    The transform is performed as follows:
+
+    ```
+      :    i0    i1       i2       i3    i4
+      :    |     |        |        |     |
+      :  +---------+ +---------+ +----------+
+      :  |    A    | |    B    | |    C     |
+      :  +---------+ +---------+ +----------+
+      :    |     |     |     |        |
+      :    o0    o1    o2    o3       o4
+    ```
+
+    If reordering of the input or output axes is required, use in series
+    with the `remap_axes` transform.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equal_area-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equal_area-1.3.0
+  title: Alber's conic equal area projection.
+  description: |-
+    Corresponds to the `COE` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.3.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \gamma / 2 \\
+      R_\theta &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin \theta} \\
+      Y_0 &= \frac{180^\circ}{\pi} \frac{2}{\gamma} \sqrt{1 + \sin \theta_1 \sin \theta_2 - \gamma \sin((\theta_1 + \theta_2)/2)}$$
+
+    where:
+
+    $$\gamma = \sin \theta_1 + \sin \theta_2$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_equidistant-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_equidistant-1.3.0
+  title: Conic equidistant projection.
+  description: |-
+    Corresponds to the `COD` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.3.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{180^\circ}{\pi} \frac{\sin\theta_a\sin\eta}{\eta} \\
+      R_\theta &= \theta_a - \theta + \eta\cot\eta\cot\theta_a \\
+      Y_0 = \eta\cot\eta\cot\theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_orthomorphic-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_orthomorphic-1.3.0
+  title: Conic orthomorphic projection.
+  description: |-
+    Corresponds to the `COO` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.3.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \frac{\ln \left( \frac{\cos\theta_2}{\cos\theta_1} \right)}
+                {\ln \left[ \frac{\tan\left(\frac{90^\circ-\theta_2}{2}\right)}
+                                 {\tan\left(\frac{90^\circ-\theta_1}{2}\right)} \right] } \\
+      R_\theta &= \psi \left[ \tan \left( \frac{90^\circ - \theta}{2} \right) \right]^C \\
+      Y_0 &= \psi \left[ \tan \left( \frac{90^\circ - \theta_a}{2} \right) \right]^C$$
+
+    where:
+
+    $$\psi = \frac{180^\circ}{\pi} \frac{\cos \theta}
+             {C\left[\tan\left(\frac{90^\circ-\theta}{2}\right)\right]^C}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/conic_perspective-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/conic_perspective-1.3.0
+  title: Colles' conic perspecitve projection.
+  description: |-
+    Corresponds to the `COP` projection in the FITS WCS standard.
+
+    See
+    [conic](ref:transform/conic-1.3.0)
+    for the definition of the full transformation.
+
+    The transformation is defined as:
+
+    $$C &= \sin \theta_a \\
+      R_\theta &= \frac{180^\circ}{\pi} \cos \eta [ \cot \theta_a - \tan(\theta - \theta_a)] \\
+      Y_0 &= \frac{180^\circ}{\pi} \cos \eta \cot \theta_a$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/constant-1.4.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/constant-1.4.0
+  title: A Constant transform.
+  description: |-
+    Invertibility: A transform which takes one or two inputs based on
+    dimensionality and returns a constant value. It has no analytical inverse.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_equal_area-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_equal_area-1.3.0
+  title: The cylindrical equal area projection.
+  description: |-
+    Corresponds to the `CEA` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= \sin^{-1}\left(\frac{\pi}{180^{\circ}}\lambda y\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\frac{\sin \theta}{\lambda}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/cylindrical_perspective-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/cylindrical_perspective-1.3.0
+  title: The cylindrical perspective projection.
+  description: |-
+    Corresponds to the `CYP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\lambda} \\
+    \theta &= \arg(1, \eta) + \sin{-1}\left(\frac{\eta \mu}{\sqrt{\eta^2 + 1}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \lambda \phi \\
+    y &= \frac{180^{\circ}}{\pi}\left(\frac{\mu + \lambda}{\mu + \cos \theta}\right)\sin \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/disk2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/disk2d-1.0.0
+  title: Two dimensional disk model.
+  description: |-
+    Two dimensional radially symmetric disk.
+- tag_uri: tag:stsci.edu:asdf/transform/divide-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/divide-1.2.0
+  title: Perform a list of subtransforms in parallel and then divide their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/drude1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/drude1d-1.0.0
+  title: One dimensional Drude model
+  description: |-
+    Drude model based one the behavior of electons in materials (esp. metals).
+- tag_uri: tag:stsci.edu:asdf/transform/ellipse2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/ellipse2d-1.0.0
+  title: Two dimensional ellipse model.
+  description: |-
+    Two dimensional ellipse.
+- tag_uri: tag:stsci.edu:asdf/transform/exponential1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/exponential1d-1.0.0
+  title: One dimensional exponential model.
+  description: |-
+    One dimensional exponential model.
+- tag_uri: tag:stsci.edu:asdf/transform/exponential_cutoff_power_law1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/exponential_cutoff_power_law1d-1.0.0
+  title: One dimensional power law model with an exponential cutoff.
+  description: |-
+    One dimensional power law model with an exponential cutoff.
+- tag_uri: tag:stsci.edu:asdf/transform/fix_inputs-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/fix_inputs-1.2.0
+  title: Set to a constant selected input arguments of a model.
+  description: |-
+    This operation takes as the right hand side a dict equivalent
+    that consists of key:value pairs where the key identifies
+    the input argument to be set, either by position number
+    (0 based) or name, and the value is the floating point value
+    that should be assigned to that input. The result is a
+    compound model with n fewer input arguments where n is
+    the number of input values to be set (i.e., the number
+    of keys in the dict).
+- tag_uri: tag:stsci.edu:asdf/transform/gaussian1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/gaussian1d-1.0.0
+  title: A 1D Gaussian model.
+  description: |-
+    A 1D gaussian distribution.
+- tag_uri: tag:stsci.edu:asdf/transform/gaussian2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/gaussian2d-1.0.0
+  title: A 2D Gaussian model.
+  description: |-
+    A 2D gaussian distribution.
+- tag_uri: tag:stsci.edu:asdf/transform/generic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/generic-1.2.0
+  title: A generic transform.
+  description: |-
+    This is used **entirely** for bootstrapping purposes so one can create composite models including transforms that haven't yet been written.  **IT WILL NOT BE IN THE FINAL VERSION OF THE SPEC**.
+- tag_uri: tag:stsci.edu:asdf/transform/gnomonic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/gnomonic-1.2.0
+  title: The gnomonic projection.
+  description: |-
+    Corresponds to the `TAN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/hammer_aitoff-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/hammer_aitoff-1.2.0
+  title: Hammer-Aitoff projection.
+  description: |-
+    Corresponds to the `AIT` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= 2 \arg \left(2Z^2 - 1, \frac{\pi}{180^\circ} \frac{Z}{2}x\right) \\
+      \theta &= \sin^{-1}\left(\frac{\pi}{180^\circ}yZ\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= 2 \gamma \cos \theta \sin \frac{\phi}{2} \\
+      y &= \gamma \sin \theta$$
+
+    where:
+
+    $$\gamma = \frac{180^\circ}{\pi} \sqrt{\frac{2}{1 + \cos \theta \cos(\phi / 2)}}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix-1.2.0
+  title: HEALPix projection.
+  description: |-
+    Corresponds to the `HPX` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/healpix_polar-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/healpix_polar-1.2.0
+  title: HEALPix polar, aka "butterfly", projection.
+  description: |-
+    Corresponds to the `XPH` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/identity-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/identity-1.2.0
+  title: The identity transform.
+  description: |-
+    Invertibility: The inverse of this transform is also the identity transform.
+- tag_uri: tag:stsci.edu:asdf/transform/king_projected_analytic1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/king_projected_analytic1d-1.0.0
+  title: Projected (surface density) analytic King Model.
+  description: |-
+    Projected (surface density) analytic King Model.
+- tag_uri: tag:stsci.edu:asdf/transform/linear1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/linear1d-1.0.0
+  title: A one dimensional line model
+  description: |-
+    A one dimensional line model
+- tag_uri: tag:stsci.edu:asdf/transform/log_parabola1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/log_parabola1d-1.0.0
+  title: One dimensional log parabola model (sometimes called curved power law).
+  description: |-
+    One dimensional log parabola model (sometimes called curved power law).
+- tag_uri: tag:stsci.edu:asdf/transform/logarithmic1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/logarithmic1d-1.0.0
+  title: One dimensional (natural) logarithmic model.
+  description: |-
+    One dimensional (natural) logarithmic model.
+- tag_uri: tag:stsci.edu:asdf/transform/lorentz1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/lorentz1d-1.0.0
+  title: One dimensional Lorentzian model.
+  description: |-
+    One dimensional Lorentzian model.
+- tag_uri: tag:stsci.edu:asdf/transform/math_functions-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/math_functions-1.0.0
+  title: Math functions.
+  description: |-
+    Commonly used math funcitons.
+- tag_uri: tag:stsci.edu:asdf/transform/mercator-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/mercator-1.2.0
+  title: The Mercator projection.
+  description: |-
+    Corresponds to the `MER` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= 2 \tan^{-1}\left(e^{y \pi / 180^{\circ}}\right)-90^{\circ}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \frac{180^{\circ}}{\pi}\ln \tan \left(\frac{90^{\circ} + \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/moffat1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/moffat1d-1.0.0
+  title: One dimensional Moffat model.
+  description: |-
+    One dimensional Moffat distribution.
+- tag_uri: tag:stsci.edu:asdf/transform/moffat2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/moffat2d-1.0.0
+  title: Two dimensional Moffat model.
+  description: |-
+    Two dimensional Moffat distribution.
+- tag_uri: tag:stsci.edu:asdf/transform/molleweide-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/molleweide-1.2.0
+  title: Molleweide's projection.
+  description: |-
+    Corresponds to the `MOL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{\pi x}{2 \sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}} \\
+      \theta &= \sin^{-1}\left(\frac{1}{90^\circ}\sin^{-1}\left(\frac{\pi}{180^\circ}\frac{y}{\sqrt{2}}\right) + \frac{y}{180^\circ}\sqrt{2 - \left(\frac{\pi}{180^\circ}y\right)^2}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \frac{2 \sqrt{2}}{\pi} \phi \cos \gamma \\
+      y &= \sqrt{2} \frac{180^\circ}{\pi} \sin \gamma$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/multiply-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/multiply-1.2.0
+  title: Perform a list of subtransforms in parallel and then multiply their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/multiplyscale-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/multiplyscale-1.0.0
+  title: A Multiply model.
+  description: |-
+    Multiply the input by a factor.
+- tag_uri: tag:stsci.edu:asdf/transform/ortho_polynomial-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/ortho_polynomial-1.0.0
+  title: Respresents various Orthogonal Polynomial models.
+  description: |-
+    A polynomial model represented by its coefficients stored in
+    an ndarray of shape $(n+1)$ for univariate polynomials or $(n+1, n+1)$
+    for polynomials with 2 variables, where $n$ is the highest total degree
+    of the polynomial. The property polynomial_type defines what kind of
+    polynomial is defined.
+
+    $$P = \sum_{i, j=0}^{i+j=n}c_{ij} * x^{i} * y^{j}$$
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/parabolic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/parabolic-1.2.0
+  title: Parabolic projection.
+  description: |-
+    Corresponds to the `PAR` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{180^\circ}{\pi} \frac{x}{1 - 4(y / 180^\circ)^2} \\
+      \theta &= 3 \sin^{-1}\left(\frac{y}{180^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \left(2\cos\frac{2\theta}{3} - 1\right) \\
+      y &= 180^\circ \sin \frac{\theta}{3}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/planar2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/planar2d-1.0.0
+  title: Two dimensional plane model.
+  description: |-
+    Two dimensional plane model.
+- tag_uri: tag:stsci.edu:asdf/transform/plate_carree-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/plate_carree-1.2.0
+  title: "The plate carr\xE9e projection."
+  description: |-
+    Corresponds to the `CAR` projection in the FITS WCS standard.
+
+    The main virtue of this transformation is its simplicity.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= x \\
+    \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \\
+    y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/plummer1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/plummer1d-1.0.0
+  title: Two dimensional Plummer model.
+  description: |-
+    One dimensional Plummer density profile model.
+- tag_uri: tag:stsci.edu:asdf/transform/polyconic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polyconic-1.2.0
+  title: Polyconic projection.
+  description: |-
+    Corresponds to the `PCO` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/polynomial-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/polynomial-1.2.0
+  title: A Polynomial model.
+  description: |-
+    A polynomial model represented by its coefficients stored in
+    an ndarray of shape $(n+1)$ for univariate polynomials or $(n+1, n+1)$
+    for polynomials with 2 variables, where $n$ is the highest total degree
+    of the polynomial.
+
+    $$P = \sum_{i, j=0}^{i+j=n}c_{ij} * x^{i} * y^{j}$$
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/power-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/power-1.2.0
+  title: Perform a list of subtransforms in parallel and then raise each result to
+    the power of the next.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/power_law1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/power_law1d-1.0.0
+  title: One dimensional power law model.
+  description: |-
+    One dimensional power law model.
+- tag_uri: tag:stsci.edu:asdf/transform/quad_spherical_cube-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/quad_spherical_cube-1.2.0
+  title: Quadrilateralized spherical cube projection.
+  description: |-
+    Corresponds to the `QSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/redshift_scale_factor-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/redshift_scale_factor-1.0.0
+  title: One dimensional redshift scale factor model.
+  description: |-
+    One dimensional redshift scale factor model.
+- tag_uri: tag:stsci.edu:asdf/transform/remap_axes-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/remap_axes-1.3.0
+  title: Reorder, add and drop axes.
+  description: "This transform allows the order of the input axes to be shuffled and\n\
+    returned as the output axes.\n\nIt is a list made up of integers.  Each item\n\
+    in the list corresponds to an output axis. Each item is the index of\nthe input\
+    \ axis to send to the output axis.\n\nIf an object with `mapping` and `n_inputs`\
+    \ properties is provided, the\nnumber of input axes is explicitly set by the `n_inputs`\
+    \ value.\nIf only a list is provided, the number of input axes is\nautomatically\
+    \ determined from the maximum index in the list.  \n\nInvertibility: This transform\
+    \ does not have a general analytical inverse.\nIn some well defined cases it is\
+    \ possible to invert automatically"
+- tag_uri: tag:stsci.edu:asdf/transform/ricker_wavelet1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/ricker_wavelet1d-1.0.0
+  title: One dimensional Ricker Wavelet model.
+  description: |-
+    One dimensional Ricker Wavelet model
+- tag_uri: tag:stsci.edu:asdf/transform/ricker_wavelet2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/ricker_wavelet2d-1.0.0
+  title: Two dimensional Ricker Wavelet model.
+  description: |-
+    Two dimensional Ricker Wavelet model.
+- tag_uri: tag:stsci.edu:asdf/transform/ring2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/ring2d-1.0.0
+  title: Two dimensional radially symmetric ring model.
+  description: |-
+    Two dimensional radially symmetric ring.
+- tag_uri: tag:stsci.edu:asdf/transform/rotate2d-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate2d-1.3.0
+  title: A 2D rotation.
+  description: |-
+    A 2D rotation around the origin, in degrees.
+    Invertibility: All ASDF tools are required to be able to compute the analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/rotate3d-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate3d-1.3.0
+  title: Rotation in 3D space.
+  description: |-
+    Euler angle rotation around 3 axes.
+
+    Invertibility: All ASDF tools are required to be able to compute the
+    analytic inverse of this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/rotate_sequence_3d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/rotate_sequence_3d-1.0.0
+  title: Rotation in 3D space.
+  description: |-
+    Rotation in 3D space by arbitrary number of angles about
+    arbitrary order of "x", "y", "z" axes.
+- tag_uri: tag:stsci.edu:asdf/transform/sanson_flamsteed-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/sanson_flamsteed-1.2.0
+  title: The Sanson-Flamsteed projection.
+  description: |-
+    Corresponds to the `SFL` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \frac{x}{\cos y} \\
+      \theta &= y$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= \phi \cos \theta \\
+      y &= \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/scale-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/scale-1.2.0
+  title: A Scale model.
+  description: |-
+    Scale the input by a dimensionless factor.
+- tag_uri: tag:stsci.edu:asdf/transform/sersic1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/sersic1d-1.0.0
+  title: One dimensional Sersic surface brightness profile.
+  description: |-
+    One dimensional Sersic surface brightness profile.
+- tag_uri: tag:stsci.edu:asdf/transform/sersic2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/sersic2d-1.0.0
+  title: Two dimensional Sersic surface brightness profile.
+  description: |-
+    Two dimensional Sersic surface brightness profile.
+- tag_uri: tag:stsci.edu:asdf/transform/shift-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/shift-1.2.0
+  title: A Shift opeartion.
+  description: |-
+    Apply an offset in one direction.
+- tag_uri: tag:stsci.edu:asdf/transform/sine1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/sine1d-1.0.0
+  title: One dimensional sine model.
+  description: |-
+    One dimensional sine.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_orthographic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_orthographic-1.2.0
+  title: The slant orthographic projection.
+  description: |-
+    Corresponds to the `SIN` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \cos^{-1}\left(\frac{\pi}{180^{\circ}}R_\theta\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cos \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/slant_zenithal_perspective-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/slant_zenithal_perspective-1.2.0
+  title: The slant zenithal perspective projection.
+  description: |-
+    Corresponds to the `SZP` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = \tan^{-1}\left(\frac{180^{\circ}}{\pi R_\theta}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\cot \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/smoothly_broken_power_law1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/smoothly_broken_power_law1d-1.0.0
+  title: One dimensional smoothly broken power law model.
+  description: |-
+    One dimensional smoothly broken power law model.
+- tag_uri: tag:stsci.edu:asdf/transform/stereographic-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/stereographic-1.2.0
+  title: The stereographic projection.
+  description: |-
+    Corresponds to the `STG` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^{\circ} - 2 \tan^{-1}\left(\frac{\pi R_\theta}{360^{\circ}}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = \frac{180^{\circ}}{\pi}\frac{2 \cos \theta}{1 + \sin \theta}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/subtract-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/subtract-1.2.0
+  title: Perform a list of subtransforms in parallel and then subtract their results.
+  description: |-
+    Each of the subtransforms must have the same number of inputs and
+    outputs.
+
+    Invertibility: This transform is not automatically invertible.
+- tag_uri: tag:stsci.edu:asdf/transform/tabular-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tabular-1.2.0
+  title: A Tabular model.
+  description: |-
+    Tabular represents a lookup table with values corresponding to
+    some grid points.
+    It computes the interpolated values corresponding to the given
+    inputs. Three methods of interpolation are supported -
+    "linear", "nearest" and "splinef2d". It supports extrapolation.
+- tag_uri: tag:stsci.edu:asdf/transform/tangential_spherical_cube-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/tangential_spherical_cube-1.2.0
+  title: Tangential spherical cube projection.
+  description: |-
+    Corresponds to the `TSC` projection in the FITS WCS standard.
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/trapezoid1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/trapezoid1d-1.0.0
+  title: One dimensional trapezoid model.
+  description: |-
+    One dimensional trapezoid.
+- tag_uri: tag:stsci.edu:asdf/transform/trapezoid_disk2d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/trapezoid_disk2d-1.0.0
+  title: Two dimensional circular trapezoid model.
+  description: |-
+    Two dimensional circular trapezoid.
+- tag_uri: tag:stsci.edu:asdf/transform/voigt1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/voigt1d-1.0.0
+  title: One dimensional model for the Voigt profile.
+  description: |-
+    One dimensional model for the Voigt profile.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equal_area-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equal_area-1.2.0
+  title: The zenithal equal area projection.
+  description: |-
+    Corresponds to the `ZEA` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - 2 \sin^{-1} \left(\frac{\pi R_\theta}{360^\circ}\right)$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta &= \frac{180^\circ}{\pi} \sqrt{2(1 - \sin\theta)} \\
+               &= \frac{360^\circ}{\pi} \sin\left(\frac{90^\circ - \theta}{2}\right)$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_equidistant-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_equidistant-1.2.0
+  title: The zenithal equidistant projection.
+  description: |-
+    Corresponds to the `ARC` projection in the FITS WCS standard.
+
+    See
+    [zenithal](ref:transform/zenithal-1.2.0)
+    for the definition of the full transformation.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\theta = 90^\circ - R_\theta$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$R_\theta = 90^\circ - \theta$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.
+- tag_uri: tag:stsci.edu:asdf/transform/zenithal_perspective-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/zenithal_perspective-1.3.0
+  title: The zenithal perspective projection.
+  description: |-
+    Corresponds to the `AZP` projection in the FITS WCS standard.
+
+    The pixel-to-sky transformation is defined as:
+
+    $$\phi &= \arg(-y \cos \gamma, x) \\
+    \theta &= \left\{\genfrac{}{}{0pt}{}{\psi - \omega}{\psi + \omega + 180^{\circ}}\right.$$
+
+    where:
+
+    $$\psi &= \arg(\rho, 1) \\
+    \omega &= \sin^{-1}\left(\frac{\rho \mu}{\sqrt{\rho^2 + 1}}\right) \\
+    \rho &= \frac{R}{\frac{180^{\circ}}{\pi}(\mu + 1) + y \sin \gamma} \\
+    R &= \sqrt{x^2 + y^2 \cos^2 \gamma}$$
+
+    And the sky-to-pixel transformation is defined as:
+
+    $$x &= R \sin \phi \\
+    y &= -R \sec \gamma \cos \theta$$
+
+    where:
+
+    $$R = \frac{180^{\circ}}{\pi} \frac{(\mu + 1) \cos \theta}{(\mu + \sin \theta) + \cos \theta \cos \phi \tan \gamma}$$
+
+    Invertibility: All ASDF tools are required to provide the inverse of
+    this transform.

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -23,27 +23,43 @@ yaml.add_representer(MultilineString, represent_multiline_string)
 
 args = parse_args()
 
-asdf_standard_version = args.version_map_path.split("/")[-1].rsplit(".", 1)[0].split("-")[-1]
+asdf_standard_version = (
+    args.version_map_path.split("/")[-1].rsplit(".", 1)[0].split("-")[-1]
+)
 
 with open(args.version_map_path) as f:
     version_map = yaml.safe_load(f.read())
 
 manifest = {}
 
-manifest["id"] = f"http://stsci.edu/asdf/extensions/transform/manifests/transform-{asdf_standard_version}"
-manifest["extension_uri"] = f"http://stsci.edu/asdf/extensions/transform-{asdf_standard_version}"
+manifest[
+    "id"
+] = f"http://stsci.edu/asdf/extensions/transform/manifests/transform-{asdf_standard_version}"
+manifest[
+    "extension_uri"
+] = f"http://stsci.edu/asdf/extensions/transform-{asdf_standard_version}"
 manifest["title"] = f"Transform extension {asdf_standard_version}"
-manifest["description"] = MultilineString("A set of tags for serializing data transforms.")
+manifest["description"] = MultilineString(
+    "A set of tags for serializing data transforms."
+)
 manifest["asdf_standard_requirement"] = asdf_standard_version
 manifest["tags"] = []
 
 for tag_base, tag_version in version_map["tags"].items():
     if tag_base.startswith("tag:stsci.edu:asdf/transform/"):
         tag_uri = f"{tag_base}-{tag_version}"
-        schema_uri = tag_uri.replace("tag:stsci.edu:asdf/transform/", "http://stsci.edu/schemas/asdf/transform/")
+        schema_uri = tag_uri.replace(
+            "tag:stsci.edu:asdf/transform/", "http://stsci.edu/schemas/asdf/transform/"
+        )
         schema = asdf.schema.load_schema(schema_uri)
-        manifest["tags"].append({"tag_uri": tag_uri, "schema_uri": schema_uri, "title": schema["title"].strip(), "description": MultilineString(schema["description"].strip())})
+        manifest["tags"].append(
+            {
+                "tag_uri": tag_uri,
+                "schema_uri": schema_uri,
+                "title": schema["title"].strip(),
+                "description": MultilineString(schema["description"].strip()),
+            }
+        )
 
 with open(args.output_path, "w") as f:
     yaml.dump(manifest, f, sort_keys=False)
-

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -1,3 +1,8 @@
+"""
+Script that creates initial transform manifests from the version_map
+files in the asdf-standard repo.  This file can be removed once
+the format of the manifest files has been finalized.
+"""
 import argparse
 
 import yaml

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -1,0 +1,49 @@
+import argparse
+
+import yaml
+import asdf
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version_map_path")
+    parser.add_argument("output_path")
+    return parser.parse_args()
+
+
+class MultilineString(str):
+    pass
+
+
+def represent_multiline_string(dumper, data):
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+
+
+yaml.add_representer(MultilineString, represent_multiline_string)
+
+args = parse_args()
+
+asdf_standard_version = args.version_map_path.split("/")[-1].rsplit(".", 1)[0].split("-")[-1]
+
+with open(args.version_map_path) as f:
+    version_map = yaml.safe_load(f.read())
+
+manifest = {}
+
+manifest["id"] = f"http://stsci.edu/asdf/extensions/transform/manifests/transform-{asdf_standard_version}"
+manifest["extension_uri"] = f"http://stsci.edu/asdf/extensions/transform-{asdf_standard_version}"
+manifest["title"] = f"Transform extension {asdf_standard_version}"
+manifest["description"] = MultilineString("A set of tags for serializing data transforms.")
+manifest["asdf_standard_requirement"] = asdf_standard_version
+manifest["tags"] = []
+
+for tag_base, tag_version in version_map["tags"].items():
+    if tag_base.startswith("tag:stsci.edu:asdf/transform/"):
+        tag_uri = f"{tag_base}-{tag_version}"
+        schema_uri = tag_uri.replace("tag:stsci.edu:asdf/transform/", "http://stsci.edu/schemas/asdf/transform/")
+        schema = asdf.schema.load_schema(schema_uri)
+        manifest["tags"].append({"tag_uri": tag_uri, "schema_uri": schema_uri, "title": schema["title"].strip(), "description": MultilineString(schema["description"].strip())})
+
+with open(args.output_path, "w") as f:
+    yaml.dump(manifest, f, sort_keys=False)
+

--- a/src/asdf_transform_schemas/integration.py
+++ b/src/asdf_transform_schemas/integration.py
@@ -24,5 +24,9 @@ def get_resource_mappings():
         DirectoryResourceMapping(
             resources_root / "stsci.edu" / "schemas",
             "http://stsci.edu/schemas/asdf/transform",
-        )
+        ),
+        DirectoryResourceMapping(
+            resources_root / "stsci.edu" / "manifests",
+            "http://stsci.edu/asdf/extensions/transform/manifests",
+        ),
     ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,9 @@ def test_resources():
 
 
 def test_manifests():
-    manifests_root = Path(__file__).parent.parent / "resources" / "stsci.edu" / "manifests"
+    manifests_root = (
+        Path(__file__).parent.parent / "resources" / "stsci.edu" / "manifests"
+    )
     resource_manager = asdf.get_config().resource_manager
 
     for manifest_path in manifests_root.glob("*.yaml"):
@@ -25,7 +27,9 @@ def test_manifests():
             manifest_content = f.read()
         manifest = yaml.safe_load(manifest_content)
 
-        manifest_schema = asdf.schema.load_schema("asdf://asdf-format.org/core/schemas/extension_manifest-1.0")
+        manifest_schema = asdf.schema.load_schema(
+            "asdf://asdf-format.org/core/schemas/extension_manifest-1.0"
+        )
 
         # The manifest must be valid against its own schema:
         asdf.schema.validate(manifest, schema=manifest_schema)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,13 +4,32 @@ import asdf
 import yaml
 
 
-def test_schemas():
-    schemas_root = Path(__file__).parent.parent / "resources" / "stsci.edu" / "schemas"
+def test_resources():
+    resources_root = Path(__file__).parent.parent / "resources"
     resource_manager = asdf.get_config().resource_manager
 
-    for schema_path in schemas_root.glob("*.yaml"):
-        with schema_path.open("rb") as f:
-            schema_content = f.read()
-        schema = yaml.safe_load(schema_content)
-        schema_uri = schema["id"]
-        assert resource_manager[schema_uri] == schema_content
+    for resource_path in resources_root.glob("**/*.yaml"):
+        with resource_path.open("rb") as f:
+            resource_content = f.read()
+        resource = yaml.safe_load(resource_content)
+        resource_uri = resource["id"]
+        assert resource_manager[resource_uri] == resource_content
+
+
+def test_manifests():
+    manifests_root = Path(__file__).parent.parent / "resources" / "stsci.edu" / "manifests"
+    resource_manager = asdf.get_config().resource_manager
+
+    for manifest_path in manifests_root.glob("*.yaml"):
+        with manifest_path.open("rb") as f:
+            manifest_content = f.read()
+        manifest = yaml.safe_load(manifest_content)
+
+        manifest_schema = asdf.schema.load_schema("asdf://asdf-format.org/core/schemas/extension_manifest-1.0")
+
+        # The manifest must be valid against its own schema:
+        asdf.schema.validate(manifest, schema=manifest_schema)
+
+        for tag_definition in manifest["tags"]:
+            # The tag's schema must be available:
+            assert tag_definition["schema_uri"] in resource_manager


### PR DESCRIPTION
This PR creates manifest files for the existing transform extensions, whose versions each correspond to an ASDF Standard version.  A few questions to consider:

- Do we like including the title/description in the manifest file?  It's a good bit of content for one file.  If we want to merge schemas together, then examples will need to go into separate files and be linked to the tag entry by URI.  The alternative is to continue to maintain the one-schema-per-tag system.

- Is there a need for a separate "implementation description" property?  Long term I've been assuming that we'll use the title and description as display values to users in notebooks, and if we do that it may be nice to move some of the nitty gritty details into a third string property.

- I put the manifest ids and the extension URIs into `http://stsci.edu` URIs, under the "what happens in stsci.edu, stays in stsci.edu" principle.  An example:

```
id: http://stsci.edu/asdf/extensions/transform/manifests/transform-1.0.0
extension_uri: http://stsci.edu/asdf/extensions/transform-1.0.0
```

Are those reasonable choices?