### PR TITLE
Remove asdf_standard_requirement from manifests

### DIFF
--- a/resources/asdf-format.org/manifests/transform-1.0.0.yaml
+++ b/resources/asdf-format.org/manifests/transform-1.0.0.yaml
@@ -3,7 +3,6 @@ extension_uri: asdf://asdf-format.org/transform/extensions/transform-1.0.0
 title: Transform extension 1.0.0
 description: |-
   A set of tags for serializing data transforms.
-asdf_standard_requirement: 1.0.0
 tags:
 - tag_uri: tag:stsci.edu:asdf/transform/add-1.0.0
   schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.0.0

--- a/resources/asdf-format.org/manifests/transform-1.1.0.yaml
+++ b/resources/asdf-format.org/manifests/transform-1.1.0.yaml
@@ -3,7 +3,6 @@ extension_uri: asdf://asdf-format.org/transform/extensions/transform-1.1.0
 title: Transform extension 1.1.0
 description: |-
   A set of tags for serializing data transforms.
-asdf_standard_requirement: 1.1.0
 tags:
 - tag_uri: tag:stsci.edu:asdf/transform/add-1.1.0
   schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.1.0

--- a/resources/asdf-format.org/manifests/transform-1.2.0.yaml
+++ b/resources/asdf-format.org/manifests/transform-1.2.0.yaml
@@ -3,7 +3,6 @@ extension_uri: asdf://asdf-format.org/transform/extensions/transform-1.2.0
 title: Transform extension 1.2.0
 description: |-
   A set of tags for serializing data transforms.
-asdf_standard_requirement: 1.2.0
 tags:
 - tag_uri: tag:stsci.edu:asdf/transform/add-1.1.0
   schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.1.0

--- a/resources/asdf-format.org/manifests/transform-1.3.0.yaml
+++ b/resources/asdf-format.org/manifests/transform-1.3.0.yaml
@@ -3,7 +3,6 @@ extension_uri: asdf://asdf-format.org/transform/extensions/transform-1.3.0
 title: Transform extension 1.3.0
 description: |-
   A set of tags for serializing data transforms.
-asdf_standard_requirement: 1.3.0
 tags:
 - tag_uri: tag:stsci.edu:asdf/transform/add-1.1.0
   schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.1.0

--- a/resources/asdf-format.org/manifests/transform-1.4.0.yaml
+++ b/resources/asdf-format.org/manifests/transform-1.4.0.yaml
@@ -3,7 +3,6 @@ extension_uri: asdf://asdf-format.org/transform/extensions/transform-1.4.0
 title: Transform extension 1.4.0
 description: |-
   A set of tags for serializing data transforms.
-asdf_standard_requirement: 1.4.0
 tags:
 - tag_uri: tag:stsci.edu:asdf/transform/add-1.2.0
   schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.2.0

--- a/resources/asdf-format.org/manifests/transform-1.5.0.yaml
+++ b/resources/asdf-format.org/manifests/transform-1.5.0.yaml
@@ -3,8 +3,6 @@ extension_uri: asdf://asdf-format.org/transform/extensions/transform-1.5.0
 title: Transform extension 1.5.0
 description: |-
   A set of tags for serializing data transforms.
-asdf_standard_requirement:
-  gte: 1.5.0
 tags:
 - tag_uri: tag:stsci.edu:asdf/transform/add-1.2.0
   schema_uri: http://stsci.edu/schemas/asdf/transform/add-1.2.0

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -47,7 +47,6 @@ manifest["title"] = f"Transform extension {asdf_standard_version}"
 manifest["description"] = MultilineString(
     "A set of tags for serializing data transforms."
 )
-manifest["asdf_standard_requirement"] = asdf_standard_version
 manifest["tags"] = []
 
 for tag_base, tag_version in version_map["tags"].items():


### PR DESCRIPTION
These requirements are too strict, since some existing files use tags that don't correspond to their stated ASDF Standard version.