### PR TITLE
Add recursive yaml resource finding.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import os
+from pathlib import Path
 from setuptools import setup, find_packages
 
 
@@ -13,17 +13,11 @@ package_dir = {
 
 
 def package_yaml_files(directory):
-    paths = []
-    for path, _, filenames in os.walk(directory):
-        for filename in filenames:
-            if filename.endswith(".yaml"):
-                paths.append(os.path.join("..", path, filename))
-    return paths
+    paths = sorted(Path(directory).rglob("*.yaml"))
+    return [str(p.relative_to(directory)) for p in paths]
 
 
-package_data = {
-    "asdf_transform_schemas.resources": package_yaml_files("resources"),
-}
+package_data = {"asdf_transform_schemas.resources": package_yaml_files("resources")}
 
 setup(
     use_scm_version=True,

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 from setuptools import setup, find_packages
 
 
@@ -10,8 +11,18 @@ package_dir = {
     "asdf_transform_schemas.resources": "resources",
 }
 
+
+def package_yaml_files(directory):
+    paths = []
+    for path, _, filenames in os.walk(directory):
+        for filename in filenames:
+            if filename.endswith(".yaml"):
+                paths.append(os.path.join("..", path, filename))
+    return paths
+
+
 package_data = {
-    "asdf_transform_schemas.resources": ["*.yaml", "**/*.yaml", "**/**/*.yaml", "**/**/**/*.yaml"],
+    "asdf_transform_schemas.resources": package_yaml_files("resources"),
 }
 
 setup(


### PR DESCRIPTION
In PR #31,  came across an issue where the package installer was missing some of the yaml resource files. This was due to the package installer not being able to recursively find and add yaml files. Instead it was limited to a fixed file depth. This PR adds a method to recursively find and add yaml files.