### PR TITLE
Add inputs and outputs fields to the base transform schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.2.1 (unreleased)
 
 - Add schemas to properly support bounding_box and compound_bounding_box. [#31]
+- Add inputs and outputs to base transform schema to properly document them. [#33]
 
 0.2.0 (2021-12-13)
 ------------------

--- a/resources/stsci.edu/schemas/transform-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/transform-1.2.0.yaml
@@ -15,17 +15,23 @@ examples:
     - |
       !transform/transform-1.2.0
         name: test
+        inputs: ['x', 'y']
+        outputs: ['z']
   -
     - A transform with old-style 1D bounding_box
     - |
       !transform/transform-1.2.0
         name: test
+        inputs: ['x']
+        outputs: ['y']
         bounding_box: [1.0, 2.0]
   -
     - A transform with new-style 1D bounding_box
     - |
       !transform/transform-1.2.0
         name: test
+        inputs: ['x']
+        outputs: ['y']
         bounding_box: !transform/property/bounding_box-1.0.0
           intervals:
             x: [1.0, 2.0]
@@ -34,6 +40,8 @@ examples:
     - |
       !transform/transform-1.2.0
         name: test
+        inputs: ['x', 'y']
+        outputs: ['z']
         bounding_box:
           - [1.0, 2.0]
           - [3.0, 4.0]
@@ -42,6 +50,8 @@ examples:
     - |
       !transform/transform-1.2.0
         name: test
+        inputs: ['x', 'y']
+        outputs: ['z']
         bounding_box: !transform/property/bounding_box-1.0.0
           intervals:
             x: [1.0, 2.0]
@@ -51,6 +61,8 @@ examples:
     - |
       !transform/transform-1.2.0
         name: test
+        inputs: ['x', 'y', 'a', 'b']
+        outputs: ['z']
         bounding_box: !transform/property/compound_bounding_box-1.0.0
           selector_args:
             - argument: x
@@ -86,6 +98,20 @@ properties:
       can provide it automatically.
 
     $ref: "transform-1.2.0"
+
+  inputs:
+    description: |
+      The names of the model's evaluation input variables.
+    type: array
+    items:
+      type: string
+
+  outputs:
+    description: |
+      The names of the model's evaluation output variables.
+    type: array
+    items:
+      type: string
 
   bounding_box:
     description: |


### PR DESCRIPTION
This documents the `inputs` and `ouputs` fields being written by `astropy` for all models within the base transform schema.

Fixes issue #27.