### PR TITLE
Add fixed and bounds fields to the base transform schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 
 - Add schemas to properly support bounding_box and compound_bounding_box. [#31]
 - Add inputs and outputs to base transform schema to properly document them. [#33]
+- Add fixed and bounds to base transform schema to properly document them. [#34]
 
 0.2.0 (2021-12-13)
 ------------------

--- a/resources/stsci.edu/schemas/transform-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/transform-1.2.0.yaml
@@ -17,6 +17,12 @@ examples:
         name: test
         inputs: ['x', 'y']
         outputs: ['z']
+        fixed:
+          a: True
+          b: False
+        bounds:
+          c: [-1, 2]
+          d: [-3, 4]
   -
     - A transform with old-style 1D bounding_box
     - |
@@ -125,5 +131,20 @@ properties:
           $ref: "property/bounding_box-1.0.0#definitions/interval"
       - tag: tag:stsci.edu:asdf/transform/property/bounding_box-1.0.0
       - tag: tag:stsci.edu:asdf/transform/property/compound_bounding_box-1.0.0
+
+  fixed:
+    description: |
+      The parameters which are fixed when fitting the transform to data.
+    type: object
+    additionalProperties:
+      type: boolean
+
+  bounds:
+    description: |
+      The parameters which are bounded when fitting the transform to data.
+    type:
+      object
+    additionalProperties:
+      $ref: "property/bounding_box-1.0.0#definitions/interval"
 additionalProperties: true
 ...


### PR DESCRIPTION
This documents the `fixed` and `bounds` fields being written by astropy for all models within the base transform schema.

Fixes issue #28.