### PR TITLE
Bugfix to allow None as an option in the `bounds` property of a transform

### DIFF
--- a/resources/stsci.edu/schemas/transform-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/transform-1.2.0.yaml
@@ -22,7 +22,7 @@ examples:
           b: False
         bounds:
           c: [-1, 2]
-          d: [-3, 4]
+          d: [-3, null]
   -
     - A transform with old-style 1D bounding_box
     - |
@@ -87,6 +87,12 @@ examples:
                   a: [8.0, 9.0]
                   b: [10.0, 11.0]
 
+definitions:
+  bound:
+    anyOf:
+      - type: number
+      - type: "null"
+
 type: object
 properties:
   name:
@@ -145,6 +151,11 @@ properties:
     type:
       object
     additionalProperties:
-      $ref: "property/bounding_box-1.0.0#definitions/interval"
+      type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        - $ref: "#/definitions/bound"
+        - $ref: "#/definitions/bound"
 additionalProperties: true
 ...


### PR DESCRIPTION
A bound on a parameter for fitting is allowed to have the value of `None` for its `min` or `max` so that it can support single direction bounds. Currently, the `bounds` property of the transform schema does not allow for this. This updates the property to allow for this option.