### PR TITLE
Add input_units_equivalencies to transform schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 - Add schemas to properly support bounding_box and compound_bounding_box. [#31]
 - Add inputs and outputs to base transform schema to properly document them. [#33]
 - Add fixed and bounds to base transform schema to properly document them. [#34]
+- Add input_units_equivalencies to base transform schema to properly document it. [#36]
 
 0.2.0 (2021-12-13)
 ------------------

--- a/resources/stsci.edu/schemas/transform-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/transform-1.2.0.yaml
@@ -157,5 +157,12 @@ properties:
       items:
         - $ref: "#/definitions/bound"
         - $ref: "#/definitions/bound"
+
+  input_units_equivalencies:
+    description: |
+      The units that are accepted for inputs to be converted into.
+    type: object
+    additionalProperties:
+      tag: tag:astropy.org:astropy/units/equivalency-1.0.0
 additionalProperties: true
 ...


### PR DESCRIPTION
Add the `input_units_equivalencies` property introduced to the asdf serialization in astropy by PR `astropy/astropy#10198` to the transform schema.