### PR TITLE
Add `Schechter1D` model schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 - Add fixed and bounds to base transform schema to properly document them. [#34]
 - Add input_units_equivalencies to base transform schema to properly document it. [#36]
 - Update spline1d schema. [#46]
+- Add Schechter1D schema. [#54]
 
 0.2.2 (2022-02-24)
 ------------------

--- a/resources/asdf-format.org/manifests/transform-1.5.0.yaml
+++ b/resources/asdf-format.org/manifests/transform-1.5.0.yaml
@@ -660,6 +660,11 @@ tags:
   title: A Scale model.
   description: |-
     Scale the input by a dimensionless factor.
+- tag_uri: tag:stsci.edu:asdf/transform/schechter1d-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/schechter1d-1.0.0
+  title: Schechter luminosity function
+  description: |-
+    Schechter luminosity function
 - tag_uri: tag:stsci.edu:asdf/transform/sersic1d-1.0.0
   schema_uri: http://stsci.edu/schemas/asdf/transform/sersic1d-1.0.0
   title: One dimensional Sersic surface brightness profile.

--- a/resources/stsci.edu/schemas/schechter1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/schechter1d-1.0.0.yaml
@@ -1,0 +1,42 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/schechter1d-1.0.0"
+title: >
+  Schechter luminosity function
+description: >
+    Schechter luminosity function (`Schechter 1976
+    <https://ui.adsabs.harvard.edu/abs/1976ApJ...203..297S/abstract>`_),
+    parameterized in terms of magnitudes.
+examples:
+  -
+    - $$n(M) \ dM = (0.4 \ln 10) \ \phi^{*} \
+            [{10^{0.4 (M^{*} - M)}}]^{\alpha + 1} \
+            \exp{[-10^{0.4 (M^{*} - M)}]} \ dM$$
+    - |
+      !transform/schechter1d-1.0.0 {phi_star: 1.0, m_star: -20.0, alpha: -1.0}
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      phi_star:
+        anyOf:
+          - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+          - type: number
+        description: >
+          The normalization factor in units of number density.
+      m_star:
+        - type: number
+        description: >
+          The characteristic magnitude where the power-law form of the function
+          cuts off into the exponential form.
+      alpha:
+        anyOf:
+          - tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+          - type: number
+        description: >
+          The power-law index, defining the faint-end slope of the luminosity function
+    required: ['phi_star', 'm_star', 'alpha']
+...
+

--- a/resources/stsci.edu/schemas/schechter1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/schechter1d-1.0.0.yaml
@@ -27,7 +27,7 @@ allOf:
         description: >
           The normalization factor in units of number density.
       m_star:
-        - type: number
+        type: number
         description: >
           The characteristic magnitude where the power-law form of the function
           cuts off into the exponential form.
@@ -39,4 +39,3 @@ allOf:
           The power-law index, defining the faint-end slope of the luminosity function
     required: ['phi_star', 'm_star', 'alpha']
 ...
-


### PR DESCRIPTION
The `Schechter1D` model was introduced to astropy in astropy/astropy#13116, this PR adds a schema for this model.

Fixes #53