### PR TITLE
Fix broken manifest entry for fix_inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,41 @@ jobs:
         run: pip freeze
       - name: Run astropy development tests
         run: cd astropy && pytest astropy/io/misc/asdf
+
+  full-dev:
+    name: Run asdf-transform-schemas tests with both astropy and asdf-astropy development versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout asdf-transform-schemas
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: asdf-transform-schemas
+      - name: Checkout astropy dev
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: astropy/astropy
+          ref: main
+          path: astropy
+      - name: Checkout asdf-astropy dev
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: astropy/asdf-astropy
+          ref: main
+          path: asdf-astropy
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install asdf-transform-schemas
+        run: cd asdf-transform-schemas && pip install .
+      - name: Install astropy
+        run: cd astropy && pip install -e .[all,test]
+      - name: Install asdf-astropy
+        run: cd asdf-astropy && pip install -e .[test]
+      - name: Pip Freeze
+        run: pip freeze
+      - name: Run asdf-transform-schemas development tests
+        run: cd asdf-transform-schemas && pytest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 - Add input_units_equivalencies to base transform schema to properly document it. [#36]
 - Update spline1d schema. [#46]
 - Add Schechter1D schema. [#54]
+- Fix fix_inputs tag bug. [#57]
 
 0.2.2 (2022-02-24)
 ------------------

--- a/resources/asdf-format.org/manifests/transform-1.4.0.yaml
+++ b/resources/asdf-format.org/manifests/transform-1.4.0.yaml
@@ -249,8 +249,8 @@ tags:
     outputs.
 
     Invertibility: This transform is not automatically invertible.
-- tag_uri: tag:stsci.edu:asdf/transform/fix_inputs-1.2.0
-  schema_uri: http://stsci.edu/schemas/asdf/transform/fix_inputs-1.2.0
+- tag_uri: tag:stsci.edu:asdf/transform/fix_inputs-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/transform/fix_inputs-1.1.0
   title: Set to a constant selected input arguments of a model.
   description: |-
     This operation takes as the right hand side a dict equivalent


### PR DESCRIPTION
In doing some digging to resolve issue #56 I think I found a mistake in asdf-format/asdf-standard#217 which was carried into asdf-transform-schemas in #16, where in `version_map-1.4.0.yaml` the schema version for the tag for `fix_inputs` was erroneously updated to 1.2.0 from 1.1.0. This leads me to believe that the `transform-1.4.0` manifest should in-fact list `fix_inputs-1.1.0` not `fix_inputs-1.2.0`. Otherwise as noted in #56, there is no reference to the `fix_inputs-1.1.0` schema in any manifest or tag, which effectively means the schema is unreachable by the newer versions of asdf.

This PR fixes #56 by changing the fix_inputs tag in the `transform-1.4.0` manifest back to `1.1.0`.