### PR TITLE
Remove unnecessary tag from schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@
 - Fix fix_inputs tag bug. [#57]
 - Create docs for package. [#59]
 - Move packaging configuration to ``pyproject.toml``. [#62]
+- Remove unnecessary ``tag:`` entry from all schemas. [#65]
 
 0.2.2 (2022-02-24)
 ------------------

--- a/resources/stsci.edu/schemas/add-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/add-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/add-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/add-1.0.0"
 title: >
   Perform a list of subtransforms in parallel and then
   add their results together.

--- a/resources/stsci.edu/schemas/add-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/add-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/add-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/add-1.1.0"
 title: >
   Perform a list of subtransforms in parallel and then
   add their results together.

--- a/resources/stsci.edu/schemas/add-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/add-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/add-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/add-1.2.0"
 title: >
   Perform a list of subtransforms in parallel and then
   add their results together.

--- a/resources/stsci.edu/schemas/affine-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/affine-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/affine-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/affine-1.0.0"
 title: >
   An affine transform.
 description: |

--- a/resources/stsci.edu/schemas/affine-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/affine-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/affine-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/affine-1.1.0"
 title: >
   An affine transform.
 description: |

--- a/resources/stsci.edu/schemas/affine-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/affine-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/affine-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/affine-1.2.0"
 title: >
   An affine transform.
 description: |

--- a/resources/stsci.edu/schemas/affine-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/affine-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/affine-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/affine-1.3.0"
 title: >
   An affine transform.
 description: |

--- a/resources/stsci.edu/schemas/airy-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/airy-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/airy-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/airy-1.0.0"
 title: |
   The Airy projection.
 

--- a/resources/stsci.edu/schemas/airy-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/airy-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/airy-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/airy-1.1.0"
 title: |
   The Airy projection.
 

--- a/resources/stsci.edu/schemas/airy-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/airy-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/airy-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/airy-1.2.0"
 title: |
   The Airy projection.
 

--- a/resources/stsci.edu/schemas/airy_disk2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/airy_disk2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/airy_disk2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/airy_disk2d-1.0.0"
 title: >
   Two dimensional Airy disk model.
 

--- a/resources/stsci.edu/schemas/arccosine1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/arccosine1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/arccosine1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/arccosine1d-1.0.0"
 title: >
   One dimensional arccosine model.
 

--- a/resources/stsci.edu/schemas/arcsine1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/arcsine1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/arcsine1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/arcsine1d-1.0.0"
 title: >
   One dimensional arcsine model.
 

--- a/resources/stsci.edu/schemas/arctangent1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/arctangent1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/arctangent1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/arctangent1d-1.0.0"
 title: >
   One dimensional arctangent model.
 

--- a/resources/stsci.edu/schemas/blackbody-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/blackbody-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/blackbody-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/blackbody-1.0.0"
 title: >
   Blackbody model.
 

--- a/resources/stsci.edu/schemas/bonne_equal_area-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/bonne_equal_area-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/bonne_equal_area-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/bonne_equal_area-1.0.0"
 title: |
   Bonne's equal area pseudoconic projection.
 

--- a/resources/stsci.edu/schemas/bonne_equal_area-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/bonne_equal_area-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/bonne_equal_area-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/bonne_equal_area-1.1.0"
 title: |
   Bonne's equal area pseudoconic projection.
 

--- a/resources/stsci.edu/schemas/bonne_equal_area-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/bonne_equal_area-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/bonne_equal_area-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/bonne_equal_area-1.2.0"
 title: |
   Bonne's equal area pseudoconic projection.
 

--- a/resources/stsci.edu/schemas/bonne_equal_area-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/bonne_equal_area-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/bonne_equal_area-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/bonne_equal_area-1.3.0"
 title: |
   Bonne's equal area pseudoconic projection.
 

--- a/resources/stsci.edu/schemas/box1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/box1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/box1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/box1d-1.0.0"
 title: >
   One dimensional box model.
 

--- a/resources/stsci.edu/schemas/box2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/box2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/box2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/box2d-1.0.0"
 title: >
   Two dimensional box model.
 

--- a/resources/stsci.edu/schemas/broken_power_law1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/broken_power_law1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/broken_power_law1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/broken_power_law1d-1.0.0"
 title: >
   One dimensional power law model with a break.
 

--- a/resources/stsci.edu/schemas/cobe_quad_spherical_cube-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/cobe_quad_spherical_cube-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cobe_quad_spherical_cube-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/cobe_quad_spherical_cube-1.0.0"
 title: |
   COBE quadrilateralized spherical cube projection.
 

--- a/resources/stsci.edu/schemas/cobe_quad_spherical_cube-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/cobe_quad_spherical_cube-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cobe_quad_spherical_cube-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/cobe_quad_spherical_cube-1.1.0"
 title: |
   COBE quadrilateralized spherical cube projection.
 

--- a/resources/stsci.edu/schemas/cobe_quad_spherical_cube-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/cobe_quad_spherical_cube-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cobe_quad_spherical_cube-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/cobe_quad_spherical_cube-1.2.0"
 title: |
   COBE quadrilateralized spherical cube projection.
 

--- a/resources/stsci.edu/schemas/compose-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/compose-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/compose-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/compose-1.0.0"
 title: >
   Perform a list of subtransforms in series.
 

--- a/resources/stsci.edu/schemas/compose-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/compose-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/compose-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/compose-1.1.0"
 title: >
   Perform a list of subtransforms in series.
 

--- a/resources/stsci.edu/schemas/compose-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/compose-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/compose-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/compose-1.2.0"
 title: >
   Perform a list of subtransforms in series.
 

--- a/resources/stsci.edu/schemas/concatenate-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/concatenate-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/concatenate-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/concatenate-1.0.0"
 title: >
   Send axes to different subtransforms.
 

--- a/resources/stsci.edu/schemas/concatenate-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/concatenate-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/concatenate-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/concatenate-1.1.0"
 title: >
   Send axes to different subtransforms.
 

--- a/resources/stsci.edu/schemas/concatenate-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/concatenate-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/concatenate-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/concatenate-1.2.0"
 title: >
   Send axes to different subtransforms.
 

--- a/resources/stsci.edu/schemas/conic_equal_area-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/conic_equal_area-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_equal_area-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/conic_equal_area-1.0.0"
 title: |
   Alber's conic equal area projection.
 

--- a/resources/stsci.edu/schemas/conic_equal_area-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/conic_equal_area-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_equal_area-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/conic_equal_area-1.1.0"
 title: |
   Alber's conic equal area projection.
 

--- a/resources/stsci.edu/schemas/conic_equal_area-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/conic_equal_area-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_equal_area-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/conic_equal_area-1.2.0"
 title: |
   Alber's conic equal area projection.
 

--- a/resources/stsci.edu/schemas/conic_equal_area-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/conic_equal_area-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_equal_area-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/conic_equal_area-1.3.0"
 title: |
   Alber's conic equal area projection.
 

--- a/resources/stsci.edu/schemas/conic_equidistant-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/conic_equidistant-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_equidistant-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/conic_equidistant-1.0.0"
 title: |
   Conic equidistant projection.
 

--- a/resources/stsci.edu/schemas/conic_equidistant-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/conic_equidistant-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_equidistant-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/conic_equidistant-1.1.0"
 title: |
   Conic equidistant projection.
 

--- a/resources/stsci.edu/schemas/conic_equidistant-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/conic_equidistant-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_equidistant-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/conic_equidistant-1.2.0"
 title: |
   Conic equidistant projection.
 

--- a/resources/stsci.edu/schemas/conic_equidistant-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/conic_equidistant-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_equidistant-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/conic_equidistant-1.3.0"
 title: |
   Conic equidistant projection.
 

--- a/resources/stsci.edu/schemas/conic_orthomorphic-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/conic_orthomorphic-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_orthomorphic-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/conic_orthomorphic-1.0.0"
 title: |
   Conic orthomorphic projection.
 

--- a/resources/stsci.edu/schemas/conic_orthomorphic-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/conic_orthomorphic-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_orthomorphic-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/conic_orthomorphic-1.1.0"
 title: |
   Conic orthomorphic projection.
 

--- a/resources/stsci.edu/schemas/conic_orthomorphic-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/conic_orthomorphic-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_orthomorphic-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/conic_orthomorphic-1.2.0"
 title: |
   Conic orthomorphic projection.
 

--- a/resources/stsci.edu/schemas/conic_orthomorphic-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/conic_orthomorphic-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_orthomorphic-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/conic_orthomorphic-1.3.0"
 title: |
   Conic orthomorphic projection.
 

--- a/resources/stsci.edu/schemas/conic_perspective-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/conic_perspective-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_perspective-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/conic_perspective-1.0.0"
 title: |
   Colles' conic perspecitve projection.
 

--- a/resources/stsci.edu/schemas/conic_perspective-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/conic_perspective-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_perspective-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/conic_perspective-1.1.0"
 title: |
   Colles' conic perspecitve projection.
 

--- a/resources/stsci.edu/schemas/conic_perspective-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/conic_perspective-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_perspective-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/conic_perspective-1.2.0"
 title: |
   Colles' conic perspecitve projection.
 

--- a/resources/stsci.edu/schemas/conic_perspective-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/conic_perspective-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/conic_perspective-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/conic_perspective-1.3.0"
 title: |
   Colles' conic perspecitve projection.
 

--- a/resources/stsci.edu/schemas/constant-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/constant-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/constant-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/constant-1.0.0"
 title: >
   A transform that takes no inputs and always outputs a constant
   value.

--- a/resources/stsci.edu/schemas/constant-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/constant-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/constant-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/constant-1.1.0"
 title: >
   A transform that takes no inputs and always outputs a constant
   value.

--- a/resources/stsci.edu/schemas/constant-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/constant-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/constant-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/constant-1.2.0"
 title: >
   A transform that takes no inputs and always outputs a constant
   value.

--- a/resources/stsci.edu/schemas/constant-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/constant-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/constant-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/constant-1.3.0"
 title: >
   A transform that takes no inputs and always outputs a constant
   value.

--- a/resources/stsci.edu/schemas/constant-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/constant-1.4.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/constant-1.4.0"
-tag: "tag:stsci.edu:asdf/transform/constant-1.4.0"
 title: >
   A Constant transform.
 description: |

--- a/resources/stsci.edu/schemas/cosine1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/cosine1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cosine1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/cosine1d-1.0.0"
 title: >
   One dimensional cosine model.
 

--- a/resources/stsci.edu/schemas/cylindrical_equal_area-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_equal_area-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cylindrical_equal_area-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/cylindrical_equal_area-1.0.0"
 title: |
   The cylindrical equal area projection.
 

--- a/resources/stsci.edu/schemas/cylindrical_equal_area-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_equal_area-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cylindrical_equal_area-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/cylindrical_equal_area-1.1.0"
 title: |
   The cylindrical equal area projection.
 

--- a/resources/stsci.edu/schemas/cylindrical_equal_area-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_equal_area-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cylindrical_equal_area-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/cylindrical_equal_area-1.2.0"
 title: |
   The cylindrical equal area projection.
 

--- a/resources/stsci.edu/schemas/cylindrical_equal_area-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_equal_area-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cylindrical_equal_area-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/cylindrical_equal_area-1.3.0"
 title: |
   The cylindrical equal area projection.
 

--- a/resources/stsci.edu/schemas/cylindrical_perspective-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_perspective-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cylindrical_perspective-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/cylindrical_perspective-1.0.0"
 title: |
   The cylindrical perspective projection.
 

--- a/resources/stsci.edu/schemas/cylindrical_perspective-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_perspective-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cylindrical_perspective-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/cylindrical_perspective-1.1.0"
 title: |
   The cylindrical perspective projection.
 

--- a/resources/stsci.edu/schemas/cylindrical_perspective-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_perspective-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cylindrical_perspective-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/cylindrical_perspective-1.2.0"
 title: |
   The cylindrical perspective projection.
 

--- a/resources/stsci.edu/schemas/cylindrical_perspective-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_perspective-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/cylindrical_perspective-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/cylindrical_perspective-1.3.0"
 title: |
   The cylindrical perspective projection.
 

--- a/resources/stsci.edu/schemas/disk2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/disk2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/disk2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/disk2d-1.0.0"
 title: >
   Two dimensional disk model.
 

--- a/resources/stsci.edu/schemas/divide-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/divide-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/divide-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/divide-1.0.0"
 title: >
   Perform a list of subtransforms in parallel and then
   divide their results.

--- a/resources/stsci.edu/schemas/divide-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/divide-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/divide-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/divide-1.1.0"
 title: >
   Perform a list of subtransforms in parallel and then
   divide their results.

--- a/resources/stsci.edu/schemas/divide-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/divide-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/divide-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/divide-1.2.0"
 title: >
   Perform a list of subtransforms in parallel and then
   divide their results.

--- a/resources/stsci.edu/schemas/domain-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/domain-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/domain-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/domain-1.0.0"
 title: >
   Defines the domain of an input axis. (deprecated since 1.1.0)
 

--- a/resources/stsci.edu/schemas/drude1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/drude1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/drude1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/drude1d-1.0.0"
 title: >
   One dimensional Drude model
 

--- a/resources/stsci.edu/schemas/ellipse2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/ellipse2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/ellipse2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/ellipse2d-1.0.0"
 title: >
   Two dimensional ellipse model.
 

--- a/resources/stsci.edu/schemas/exponential1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/exponential1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/exponential1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/exponential1d-1.0.0"
 title: >
   One dimensional exponential model.
 

--- a/resources/stsci.edu/schemas/exponential_cutoff_power_law1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/exponential_cutoff_power_law1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/exponential_cutoff_power_law1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/exponential_cutoff_power_law1d-1.0.0"
 title: >
   One dimensional power law model with an exponential cutoff.
 

--- a/resources/stsci.edu/schemas/fix_inputs-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/fix_inputs-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/fix_inputs-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/fix_inputs-1.1.0"
 title: >
   Set to a constant selected input arguments of a model.
 

--- a/resources/stsci.edu/schemas/fix_inputs-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/fix_inputs-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/fix_inputs-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/fix_inputs-1.2.0"
 title: >
   Set to a constant selected input arguments of a model.
 

--- a/resources/stsci.edu/schemas/gaussian1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/gaussian1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/gaussian1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/gaussian1d-1.0.0"
 title: >
   A 1D Gaussian model.
 

--- a/resources/stsci.edu/schemas/gaussian2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/gaussian2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/gaussian2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/gaussian2d-1.0.0"
 title: >
   A 2D Gaussian model.
 

--- a/resources/stsci.edu/schemas/gnomonic-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/gnomonic-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/gnomonic-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/gnomonic-1.0.0"
 title: |
   The gnomonic projection.
 

--- a/resources/stsci.edu/schemas/gnomonic-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/gnomonic-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/gnomonic-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/gnomonic-1.1.0"
 title: |
   The gnomonic projection.
 

--- a/resources/stsci.edu/schemas/gnomonic-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/gnomonic-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/gnomonic-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/gnomonic-1.2.0"
 title: |
   The gnomonic projection.
 

--- a/resources/stsci.edu/schemas/hammer_aitoff-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/hammer_aitoff-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/hammer_aitoff-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/hammer_aitoff-1.0.0"
 title: |
   Hammer-Aitoff projection.
 

--- a/resources/stsci.edu/schemas/hammer_aitoff-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/hammer_aitoff-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/hammer_aitoff-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/hammer_aitoff-1.1.0"
 title: |
   Hammer-Aitoff projection.
 

--- a/resources/stsci.edu/schemas/hammer_aitoff-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/hammer_aitoff-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/hammer_aitoff-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/hammer_aitoff-1.2.0"
 title: |
   Hammer-Aitoff projection.
 

--- a/resources/stsci.edu/schemas/healpix-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/healpix-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/healpix-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/healpix-1.0.0"
 title: |
   HEALPix projection.
 

--- a/resources/stsci.edu/schemas/healpix-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/healpix-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/healpix-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/healpix-1.1.0"
 title: |
   HEALPix projection.
 

--- a/resources/stsci.edu/schemas/healpix-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/healpix-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/healpix-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/healpix-1.2.0"
 title: |
   HEALPix projection.
 

--- a/resources/stsci.edu/schemas/healpix_polar-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/healpix_polar-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/healpix_polar-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/healpix_polar-1.0.0"
 title: |
   HEALPix polar, aka "butterfly", projection.
 

--- a/resources/stsci.edu/schemas/healpix_polar-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/healpix_polar-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/healpix_polar-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/healpix_polar-1.1.0"
 title: |
   HEALPix polar, aka "butterfly", projection.
 

--- a/resources/stsci.edu/schemas/healpix_polar-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/healpix_polar-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/healpix_polar-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/healpix_polar-1.2.0"
 title: |
   HEALPix polar, aka "butterfly", projection.
 

--- a/resources/stsci.edu/schemas/identity-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/identity-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/identity-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/identity-1.0.0"
 title: >
   The identity transform.
 description: >

--- a/resources/stsci.edu/schemas/identity-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/identity-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/identity-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/identity-1.1.0"
 title: >
   The identity transform.
 description: >

--- a/resources/stsci.edu/schemas/identity-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/identity-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/identity-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/identity-1.2.0"
 title: >
   The identity transform.
 description: >

--- a/resources/stsci.edu/schemas/king_projected_analytic1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/king_projected_analytic1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/king_projected_analytic1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/king_projected_analytic1d-1.0.0"
 title: >
   Projected (surface density) analytic King Model.
 

--- a/resources/stsci.edu/schemas/label_mapper-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/label_mapper-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/label_mapper-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/label_mapper-1.0.0"
 title: >
   Represents a mapping from a coordinate value to a label.
 description: |

--- a/resources/stsci.edu/schemas/label_mapper-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/label_mapper-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/label_mapper-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/label_mapper-1.1.0"
 title: >
   Represents a mapping from a coordinate value to a label.
 description: |

--- a/resources/stsci.edu/schemas/label_mapper-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/label_mapper-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/label_mapper-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/label_mapper-1.2.0"
 title: >
   Represents a mapping from a coordinate value to a label.
 description: |

--- a/resources/stsci.edu/schemas/linear1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/linear1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/linear1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/linear1d-1.0.0"
 title: >
   A one dimensional line model
 description: >

--- a/resources/stsci.edu/schemas/log_parabola1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/log_parabola1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/log_parabola1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/log_parabola1d-1.0.0"
 title: >
   One dimensional log parabola model (sometimes called curved power law).
 

--- a/resources/stsci.edu/schemas/logarithmic1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/logarithmic1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/logarithmic1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/logarithmic1d-1.0.0"
 title: >
   One dimensional (natural) logarithmic model.
 

--- a/resources/stsci.edu/schemas/lorentz1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/lorentz1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/lorentz1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/lorentz1d-1.0.0"
 title: >
   One dimensional Lorentzian model.
 

--- a/resources/stsci.edu/schemas/math_functions-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/math_functions-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/math_functions-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/math_functions-1.0.0"
 title: >
   Math functions.
 description: |

--- a/resources/stsci.edu/schemas/mercator-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/mercator-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/mercator-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/mercator-1.0.0"
 title: |
   The Mercator projection.
 

--- a/resources/stsci.edu/schemas/mercator-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/mercator-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/mercator-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/mercator-1.1.0"
 title: |
   The Mercator projection.
 

--- a/resources/stsci.edu/schemas/mercator-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/mercator-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/mercator-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/mercator-1.2.0"
 title: |
   The Mercator projection.
 

--- a/resources/stsci.edu/schemas/moffat1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/moffat1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/moffat1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/moffat1d-1.0.0"
 title: >
   One dimensional Moffat model.
 

--- a/resources/stsci.edu/schemas/moffat2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/moffat2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/moffat2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/moffat2d-1.0.0"
 title: >
   Two dimensional Moffat model.
 

--- a/resources/stsci.edu/schemas/molleweide-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/molleweide-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/molleweide-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/molleweide-1.0.0"
 title: |
   Molleweide's projection.
 

--- a/resources/stsci.edu/schemas/molleweide-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/molleweide-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/molleweide-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/molleweide-1.1.0"
 title: |
   Molleweide's projection.
 

--- a/resources/stsci.edu/schemas/molleweide-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/molleweide-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/molleweide-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/molleweide-1.2.0"
 title: |
   Molleweide's projection.
 

--- a/resources/stsci.edu/schemas/multiply-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/multiply-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/multiply-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/multiply-1.0.0"
 title: >
   Perform a list of subtransforms in parallel and then
   multiply their results.

--- a/resources/stsci.edu/schemas/multiply-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/multiply-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/multiply-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/multiply-1.1.0"
 title: >
   Perform a list of subtransforms in parallel and then
   multiply their results.

--- a/resources/stsci.edu/schemas/multiply-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/multiply-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/multiply-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/multiply-1.2.0"
 title: >
   Perform a list of subtransforms in parallel and then
   multiply their results.

--- a/resources/stsci.edu/schemas/multiplyscale-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/multiplyscale-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/multiplyscale-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/multiplyscale-1.0.0"
 title: >
   A Multiply model.
 description: >

--- a/resources/stsci.edu/schemas/ortho_polynomial-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/ortho_polynomial-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/ortho_polynomial-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/ortho_polynomial-1.0.0"
 title: >
   Respresents various Orthogonal Polynomial models.
 

--- a/resources/stsci.edu/schemas/parabolic-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/parabolic-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/parabolic-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/parabolic-1.0.0"
 title: |
   Parabolic projection.
 

--- a/resources/stsci.edu/schemas/parabolic-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/parabolic-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/parabolic-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/parabolic-1.1.0"
 title: |
   Parabolic projection.
 

--- a/resources/stsci.edu/schemas/parabolic-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/parabolic-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/parabolic-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/parabolic-1.2.0"
 title: |
   Parabolic projection.
 

--- a/resources/stsci.edu/schemas/planar2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/planar2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/planar2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/planar2d-1.0.0"
 title: >
   Two dimensional plane model.
 

--- a/resources/stsci.edu/schemas/plate_carree-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/plate_carree-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/plate_carree-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/plate_carree-1.0.0"
 title: |
   The plate carrée projection.
 

--- a/resources/stsci.edu/schemas/plate_carree-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/plate_carree-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/plate_carree-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/plate_carree-1.1.0"
 title: |
   The plate carrée projection.
 

--- a/resources/stsci.edu/schemas/plate_carree-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/plate_carree-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/plate_carree-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/plate_carree-1.2.0"
 title: |
   The plate carrée projection.
 

--- a/resources/stsci.edu/schemas/plummer1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/plummer1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/plummer1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/plummer1d-1.0.0"
 title: >
   Two dimensional Plummer model.
 

--- a/resources/stsci.edu/schemas/polyconic-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/polyconic-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/polyconic-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/polyconic-1.0.0"
 title: |
   Polyconic projection.
 

--- a/resources/stsci.edu/schemas/polyconic-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/polyconic-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/polyconic-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/polyconic-1.1.0"
 title: |
   Polyconic projection.
 

--- a/resources/stsci.edu/schemas/polyconic-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/polyconic-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/polyconic-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/polyconic-1.2.0"
 title: |
   Polyconic projection.
 

--- a/resources/stsci.edu/schemas/polynomial-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/polynomial-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/polynomial-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/polynomial-1.0.0"
 title: >
   A Polynomial model.
 

--- a/resources/stsci.edu/schemas/polynomial-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/polynomial-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/polynomial-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/polynomial-1.1.0"
 title: >
   A Polynomial model.
 

--- a/resources/stsci.edu/schemas/polynomial-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/polynomial-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/polynomial-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/polynomial-1.2.0"
 title: >
   A Polynomial model.
 

--- a/resources/stsci.edu/schemas/power-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/power-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/power-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/power-1.0.0"
 title: >
   Perform a list of subtransforms in parallel and then raise each
   result to the power of the next.

--- a/resources/stsci.edu/schemas/power-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/power-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/power-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/power-1.1.0"
 title: >
   Perform a list of subtransforms in parallel and then raise each
   result to the power of the next.

--- a/resources/stsci.edu/schemas/power-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/power-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/power-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/power-1.2.0"
 title: >
   Perform a list of subtransforms in parallel and then raise each
   result to the power of the next.

--- a/resources/stsci.edu/schemas/power_law1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/power_law1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/power_law1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/power_law1d-1.0.0"
 title: >
   One dimensional power law model.
 

--- a/resources/stsci.edu/schemas/quad_spherical_cube-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/quad_spherical_cube-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/quad_spherical_cube-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/quad_spherical_cube-1.0.0"
 title: |
   Quadrilateralized spherical cube projection.
 

--- a/resources/stsci.edu/schemas/quad_spherical_cube-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/quad_spherical_cube-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/quad_spherical_cube-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/quad_spherical_cube-1.1.0"
 title: |
   Quadrilateralized spherical cube projection.
 

--- a/resources/stsci.edu/schemas/quad_spherical_cube-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/quad_spherical_cube-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/quad_spherical_cube-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/quad_spherical_cube-1.2.0"
 title: |
   Quadrilateralized spherical cube projection.
 

--- a/resources/stsci.edu/schemas/redshift_scale_factor-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/redshift_scale_factor-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/redshift_scale_factor-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/redshift_scale_factor-1.0.0"
 title: >
   One dimensional redshift scale factor model.
 

--- a/resources/stsci.edu/schemas/regions_selector-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/regions_selector-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/regions_selector-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/regions_selector-1.0.0"
 title: >
   Represents a discontinuous transform.
 description: |

--- a/resources/stsci.edu/schemas/regions_selector-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/regions_selector-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/regions_selector-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/regions_selector-1.1.0"
 title: >
   Represents a discontinuous transform.
 description: |

--- a/resources/stsci.edu/schemas/regions_selector-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/regions_selector-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/regions_selector-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/regions_selector-1.2.0"
 title: >
   Represents a discontinuous transform.
 description: |

--- a/resources/stsci.edu/schemas/remap_axes-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/remap_axes-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/remap_axes-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/remap_axes-1.0.0"
 title: >
   Reorder, add and drop axes.
 

--- a/resources/stsci.edu/schemas/remap_axes-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/remap_axes-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/remap_axes-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/remap_axes-1.1.0"
 title: >
   Reorder, add and drop axes.
 

--- a/resources/stsci.edu/schemas/remap_axes-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/remap_axes-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/remap_axes-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/remap_axes-1.2.0"
 title: >
   Reorder, add and drop axes.
 

--- a/resources/stsci.edu/schemas/remap_axes-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/remap_axes-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/remap_axes-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/remap_axes-1.3.0"
 title: >
   Reorder, add and drop axes.
 

--- a/resources/stsci.edu/schemas/ricker_wavelet1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/ricker_wavelet1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/ricker_wavelet1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/ricker_wavelet1d-1.0.0"
 title: >
   One dimensional Ricker Wavelet model.
 

--- a/resources/stsci.edu/schemas/ricker_wavelet2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/ricker_wavelet2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/ricker_wavelet2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/ricker_wavelet2d-1.0.0"
 title: >
   Two dimensional Ricker Wavelet model.
 

--- a/resources/stsci.edu/schemas/ring2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/ring2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/ring2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/ring2d-1.0.0"
 title: >
   Two dimensional radially symmetric ring model.
 

--- a/resources/stsci.edu/schemas/rotate2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/rotate2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/rotate2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/rotate2d-1.0.0"
 title: >
   A 2D rotation.
 description: >

--- a/resources/stsci.edu/schemas/rotate2d-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/rotate2d-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/rotate2d-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/rotate2d-1.1.0"
 title: >
   A 2D rotation.
 description: >

--- a/resources/stsci.edu/schemas/rotate2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/rotate2d-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/rotate2d-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/rotate2d-1.2.0"
 title: >
   A 2D rotation.
 description: >

--- a/resources/stsci.edu/schemas/rotate2d-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/rotate2d-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/rotate2d-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/rotate2d-1.3.0"
 title: >
   A 2D rotation.
 description: >

--- a/resources/stsci.edu/schemas/rotate3d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/rotate3d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/rotate3d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/rotate3d-1.0.0"
 title: >
   Rotation in 3D space.
 description: |

--- a/resources/stsci.edu/schemas/rotate3d-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/rotate3d-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/rotate3d-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/rotate3d-1.1.0"
 title: >
   Rotation in 3D space.
 description: |

--- a/resources/stsci.edu/schemas/rotate3d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/rotate3d-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/rotate3d-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/rotate3d-1.2.0"
 title: >
   Rotation in 3D space.
 description: |

--- a/resources/stsci.edu/schemas/rotate3d-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/rotate3d-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/rotate3d-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/rotate3d-1.3.0"
 title: >
   Rotation in 3D space.
 description: |

--- a/resources/stsci.edu/schemas/rotate_sequence_3d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/rotate_sequence_3d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/rotate_sequence_3d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/rotate_sequence_3d-1.0.0"
 title: >
   Rotation in 3D space.
 description: |

--- a/resources/stsci.edu/schemas/sanson_flamsteed-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/sanson_flamsteed-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/sanson_flamsteed-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/sanson_flamsteed-1.0.0"
 title: |
   The Sanson-Flamsteed projection.
 

--- a/resources/stsci.edu/schemas/sanson_flamsteed-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/sanson_flamsteed-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/sanson_flamsteed-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/sanson_flamsteed-1.1.0"
 title: |
   The Sanson-Flamsteed projection.
 

--- a/resources/stsci.edu/schemas/sanson_flamsteed-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/sanson_flamsteed-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/sanson_flamsteed-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/sanson_flamsteed-1.2.0"
 title: |
   The Sanson-Flamsteed projection.
 

--- a/resources/stsci.edu/schemas/scale-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/scale-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/scale-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/scale-1.0.0"
 title: >
   A Scale model.
 description: >

--- a/resources/stsci.edu/schemas/scale-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/scale-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/scale-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/scale-1.1.0"
 title: >
   A Scale model.
 description: >

--- a/resources/stsci.edu/schemas/scale-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/scale-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/scale-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/scale-1.2.0"
 title: >
   A Scale model.
 description: >

--- a/resources/stsci.edu/schemas/sersic1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/sersic1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/sersic1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/sersic1d-1.0.0"
 title: >
   One dimensional Sersic surface brightness profile.
 

--- a/resources/stsci.edu/schemas/sersic2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/sersic2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/sersic2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/sersic2d-1.0.0"
 title: >
   Two dimensional Sersic surface brightness profile.
 

--- a/resources/stsci.edu/schemas/shift-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/shift-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/shift-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/shift-1.0.0"
 title: >
   A Shift opeartion.
 description: >

--- a/resources/stsci.edu/schemas/shift-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/shift-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/shift-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/shift-1.1.0"
 title: >
   A Shift opeartion.
 description: >

--- a/resources/stsci.edu/schemas/shift-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/shift-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/shift-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/shift-1.2.0"
 title: >
   A Shift opeartion.
 description: >

--- a/resources/stsci.edu/schemas/sine1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/sine1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/sine1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/sine1d-1.0.0"
 title: >
   One dimensional sine model.
 

--- a/resources/stsci.edu/schemas/slant_orthographic-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/slant_orthographic-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/slant_orthographic-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/slant_orthographic-1.0.0"
 title: |
   The slant orthographic projection.
 

--- a/resources/stsci.edu/schemas/slant_orthographic-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/slant_orthographic-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/slant_orthographic-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/slant_orthographic-1.1.0"
 title: |
   The slant orthographic projection.
 

--- a/resources/stsci.edu/schemas/slant_orthographic-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/slant_orthographic-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/slant_orthographic-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/slant_orthographic-1.2.0"
 title: |
   The slant orthographic projection.
 

--- a/resources/stsci.edu/schemas/slant_zenithal_perspective-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/slant_zenithal_perspective-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/slant_zenithal_perspective-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/slant_zenithal_perspective-1.0.0"
 title: |
   The slant zenithal perspective projection.
 

--- a/resources/stsci.edu/schemas/slant_zenithal_perspective-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/slant_zenithal_perspective-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/slant_zenithal_perspective-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/slant_zenithal_perspective-1.1.0"
 title: |
   The slant zenithal perspective projection.
 

--- a/resources/stsci.edu/schemas/slant_zenithal_perspective-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/slant_zenithal_perspective-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/slant_zenithal_perspective-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/slant_zenithal_perspective-1.2.0"
 title: |
   The slant zenithal perspective projection.
 

--- a/resources/stsci.edu/schemas/smoothly_broken_power_law1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/smoothly_broken_power_law1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/smoothly_broken_power_law1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/smoothly_broken_power_law1d-1.0.0"
 title: >
   One dimensional smoothly broken power law model.
 

--- a/resources/stsci.edu/schemas/stereographic-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/stereographic-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/stereographic-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/stereographic-1.0.0"
 title: |
   The stereographic projection.
 

--- a/resources/stsci.edu/schemas/stereographic-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/stereographic-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/stereographic-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/stereographic-1.1.0"
 title: |
   The stereographic projection.
 

--- a/resources/stsci.edu/schemas/stereographic-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/stereographic-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/stereographic-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/stereographic-1.2.0"
 title: |
   The stereographic projection.
 

--- a/resources/stsci.edu/schemas/subtract-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/subtract-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/subtract-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/subtract-1.0.0"
 title: >
   Perform a list of subtransforms in parallel and then
   subtract their results.

--- a/resources/stsci.edu/schemas/subtract-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/subtract-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/subtract-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/subtract-1.1.0"
 title: >
   Perform a list of subtransforms in parallel and then
   subtract their results.

--- a/resources/stsci.edu/schemas/subtract-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/subtract-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/subtract-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/subtract-1.2.0"
 title: >
   Perform a list of subtransforms in parallel and then
   subtract their results.

--- a/resources/stsci.edu/schemas/tabular-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/tabular-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/tabular-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/tabular-1.0.0"
 title: >
   A Tabular model.
 description: |

--- a/resources/stsci.edu/schemas/tabular-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/tabular-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/tabular-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/tabular-1.1.0"
 title: >
   A Tabular model.
 description: |

--- a/resources/stsci.edu/schemas/tabular-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/tabular-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/tabular-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/tabular-1.2.0"
 title: >
   A Tabular model.
 description: |

--- a/resources/stsci.edu/schemas/tangent1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/tangent1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/tangent1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/tangent1d-1.0.0"
 title: >
   One dimensional tangent model.
 

--- a/resources/stsci.edu/schemas/tangential_spherical_cube-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/tangential_spherical_cube-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/tangential_spherical_cube-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/tangential_spherical_cube-1.0.0"
 title: |
   Tangential spherical cube projection.
 

--- a/resources/stsci.edu/schemas/tangential_spherical_cube-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/tangential_spherical_cube-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/tangential_spherical_cube-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/tangential_spherical_cube-1.1.0"
 title: |
   Tangential spherical cube projection.
 

--- a/resources/stsci.edu/schemas/tangential_spherical_cube-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/tangential_spherical_cube-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/tangential_spherical_cube-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/tangential_spherical_cube-1.2.0"
 title: |
   Tangential spherical cube projection.
 

--- a/resources/stsci.edu/schemas/trapezoid1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/trapezoid1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/trapezoid1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/trapezoid1d-1.0.0"
 title: >
   One dimensional trapezoid model.
 

--- a/resources/stsci.edu/schemas/trapezoid_disk2d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/trapezoid_disk2d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/trapezoid_disk2d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/trapezoid_disk2d-1.0.0"
 title: >
   Two dimensional circular trapezoid model.
 

--- a/resources/stsci.edu/schemas/voigt1d-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/voigt1d-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/voigt1d-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/voigt1d-1.0.0"
 title: >
   One dimensional model for the Voigt profile.
 

--- a/resources/stsci.edu/schemas/zenithal_equal_area-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_equal_area-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/zenithal_equal_area-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/zenithal_equal_area-1.0.0"
 title: |
   The zenithal equal area projection.
 

--- a/resources/stsci.edu/schemas/zenithal_equal_area-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_equal_area-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/zenithal_equal_area-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/zenithal_equal_area-1.1.0"
 title: |
   The zenithal equal area projection.
 

--- a/resources/stsci.edu/schemas/zenithal_equal_area-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_equal_area-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/zenithal_equal_area-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/zenithal_equal_area-1.2.0"
 title: |
   The zenithal equal area projection.
 

--- a/resources/stsci.edu/schemas/zenithal_equidistant-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_equidistant-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/zenithal_equidistant-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/zenithal_equidistant-1.0.0"
 title: |
   The zenithal equidistant projection.
 

--- a/resources/stsci.edu/schemas/zenithal_equidistant-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_equidistant-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/zenithal_equidistant-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/zenithal_equidistant-1.1.0"
 title: |
   The zenithal equidistant projection.
 

--- a/resources/stsci.edu/schemas/zenithal_equidistant-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_equidistant-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/zenithal_equidistant-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/zenithal_equidistant-1.2.0"
 title: |
   The zenithal equidistant projection.
 

--- a/resources/stsci.edu/schemas/zenithal_perspective-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_perspective-1.0.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/zenithal_perspective-1.0.0"
-tag: "tag:stsci.edu:asdf/transform/zenithal_perspective-1.0.0"
 title: |
   The zenithal perspective projection.
 

--- a/resources/stsci.edu/schemas/zenithal_perspective-1.1.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_perspective-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/zenithal_perspective-1.1.0"
-tag: "tag:stsci.edu:asdf/transform/zenithal_perspective-1.1.0"
 title: |
   The zenithal perspective projection.
 

--- a/resources/stsci.edu/schemas/zenithal_perspective-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_perspective-1.2.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/zenithal_perspective-1.2.0"
-tag: "tag:stsci.edu:asdf/transform/zenithal_perspective-1.2.0"
 title: |
   The zenithal perspective projection.
 

--- a/resources/stsci.edu/schemas/zenithal_perspective-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_perspective-1.3.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/transform/zenithal_perspective-1.3.0"
-tag: "tag:stsci.edu:asdf/transform/zenithal_perspective-1.3.0"
 title: |
   The zenithal perspective projection.
 


### PR DESCRIPTION
To keep inline with asdf-format/asdf-standard#326, this PR removes the `tag` specification from all the transform schemas. This specification is not needed because it is part of the manifest. Moreover, it makes it so that one cannot re-tag any of these schemas.