### PR TITLE
rename branch ref to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
   pull_request:


### PR DESCRIPTION
After this PR is merged the `master` branch should be renamed to `main`.