### PR TITLE
Fix badges, run ci on schedule, remove astropy from downstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   workflow_dispatch:
+  schedule:
+    # Run every Monday at 6am UTC
+    - cron: '0 6 * * 1'
   push:
     branches:
       - main

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -32,10 +32,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - package_name: astropy
-            repository: astropy/astropy
-            install_command: pip install -e .[test]
-            test_command: pytest
           - package_name: gwcs
             repository: spacetelescope/gwcs
             install_command: pip install -e .[test]

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -89,10 +89,10 @@ jobs:
           fetch-depth: 0
           repository: ${{ matrix.repository }}
           path: target
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Install asdf-transform-schemas
         run: cd asdf-transform-schemas && pip install .
       - name: Install remaining ${{ matrix.package_name }} dependencies

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -44,10 +44,6 @@ jobs:
             repository: astropy/specutils
             install_command: pip install -e .[test]
             test_command: pytest
-          - package_name: weldx
-            repository: BAMWelDX/weldx
-            install_command: pip install -e .[test]
-            test_command: pytest weldx/tests/asdf_tests weldx/schemas --asdf-tests
           - package_name: sunpy
             repository: sunpy/sunpy
             install_command: pip install -e .[tests,all]
@@ -62,10 +58,6 @@ jobs:
             test_command: pytest
           - package_name: asdf-standard
             repository: asdf-format/asdf-standard
-            install_command: pip install -e .[test]
-            test_command: pytest
-          - package_name: asdf-transform-schemas
-            repository: asdf-format/asdf-transform-schemas
             install_command: pip install -e .[test]
             test_command: pytest
           - package_name: asdf-wcs-schemas

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asdf-transform-schemas
-![CI](https://github.com/asdf-format/asdf-transform-schemas/workflows/CI/badge.svg)
-![Downstream](https://github.com/asdf-format/asdf-transform-schemas/workflows/Downstream/badge.svg)
+![CI](https://github.com/asdf-format/asdf-transform-schemas/actions/workflows/ci.yml/badge.svg)
+![Downstream](https://github.com/asdf-format/asdf-transform-schemas/actions/workflows/downstream.yml/badge.svg)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)


### PR DESCRIPTION
Use python 3.11 instead of 3.9 in downstream.

Removes weldx (which doesn't have `asdf-transform-schemas` as a dependency) and `asdf-transform-schemas` from the downstream.