### PR TITLE
docs/latex-logo-path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ------------------
 
 - Changes documentation configuration settings to make this consistent with other asdf-related projects [#117]
+- Fix typo in latex logo path [#118]
 
 0.5.0 (2024-03-08)
 ------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ configuration = conf["project"]
 
 project = configuration["name"]
 author = f"{configuration['authors'][0]['name']} <{configuration['authors'][0]['email']}>"
-copyright = f"{datetime.datetime.now().year}, {configuration['authors'][0]}"
+copyright = f"{datetime.datetime.now().year}, {author}"
 
 release = get_distribution(configuration["name"]).version
 version = ".".join(release.split(".")[:2])
@@ -160,11 +160,13 @@ graphviz_dot_args = [
 
 # -- Options for LaTeX output --------------------------------------------------
 
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title, author, documentclass [howto/manual]).
-latex_documents = [("index", project + ".tex", project + " Documentation", author, "manual")]
+# # Grouping the document tree into LaTeX files. List of tuples
+# # (source start file, target name, title, author, documentclass [howto/manual]).
+latex_documents = [("index", project + ".tex", "ASDF Transform Schemas Documentation", author, "manual")]
 
-latex_logo = "_static/images/logo-light.png"
+# The name of an image file (relative to this directory) to place at the top of
+# the title page.
+latex_logo = "_static/images/logo-light-mode.png"
 
 
 # -- Options for manual page output --------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -162,7 +162,7 @@ graphviz_dot_args = [
 
 # # Grouping the document tree into LaTeX files. List of tuples
 # # (source start file, target name, title, author, documentclass [howto/manual]).
-latex_documents = [("index", project + ".tex", "ASDF Transform Schemas Documentation", author, "manual")]
+latex_documents = [("index", project + ".tex", project + " Documentation", author, "manual")]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.


### PR DESCRIPTION
- fix typo in latex logo filename
- fix copyright text in footer ( Display `The ASDF Developers <help@stsci.edu>` instead of `{'name': 'The ASDF Developers', 'email': 'help@stsci.edu'}`)