### PR TITLE
docs/global-nav

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -41,3 +41,13 @@ div.highlight-python {
 div.highlight-python:active {
     width: 150%
 }
+
+/* Top Banner Navigation
+-------------------------------------------------- */
+.announcement-content a {
+    padding-right: 1em;
+  }
+  
+.announcement-content a:hover {
+  color: fuchsia;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ subprojects = {
     # main project
     "asdf-website": ("https://www.asdf-format.org/en/latest", None),
     # other subprojects
-    "asdf": ("https://asdf.readthedocs.io/en/latest/", None),
+    "asdf": ("https://www.asdf-format.org/projects/asdf/en/stable", None),
     "asdf-coordinates-schemas": ("https://www.asdf-format.org/projects/asdf-coordinates-schemas/en/latest/", None),
     "asdf-standard": ("https://asdf-standard.readthedocs.io/en/latest/", None),
     "asdf-wcs-schemas": ("https://www.asdf-format.org/projects/asdf-wcs-schemas/en/latest/", None),
@@ -105,6 +105,16 @@ rst_epilog += """"""  # noqa
 # the options for this theme can be modified by overriding some of the
 # variables set in the global configuration. The variables set in the
 # global configuration are listed below, commented out.
+# Adds a global navigation in the topbar - consistent across subprojects
+
+globalnavlinks = {
+    "ASDF Projects": "https://www.asdf-format.org",
+    "Tutorials": "https://www.asdf-format.org/en/latest/tutorials/index.html",
+    "Community": "https://www.asdf-format.org/en/latest/community/index.html",
+}
+topbanner = ""
+for text, link in globalnavlinks.items():
+    topbanner += f"<a href={link}>{text}</a>"
 
 # Add any paths that contain custom themes here, relative to this directory.
 # To use a different custom theme, add the directory containing the theme.
@@ -129,7 +139,9 @@ html_logo = ""
 html_theme_options = {
     "light_logo": "images/logo-light-mode.png",
     "dark_logo": "images/logo-dark-mode.png",
+    "announcement": topbanner, 
 }
+
 
 pygments_style = "monokai"
 # NB Dark style pygments is furo-specific at this time
@@ -140,7 +152,7 @@ pygments_dark_style = "monokai"
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = f"{project} v{release}"
+html_title = f"{project.replace('_', ' ')} v{'.'.join(release.split('.')[:3])}"
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = project + "doc"
@@ -179,13 +191,12 @@ sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname("__file__")), "s
 extensions += ["sphinx_asdf", "sphinx.ext.intersphinx", "sphinx.ext.extlinks"]  # noqa
 
 
-def setup(app):
-    app.add_css_file("custom.css")
-
-
 # -- sphinx_asdf configuration ---------------------------------------------
 
 # Top-level directory containing ASDF schemas (relative to current directory)
 asdf_schema_path = "../resources/stsci.edu"
 # This is the prefix common to all schema IDs in this repository
 asdf_schema_standard_prefix = "schemas"
+
+def setup(app):
+    app.add_css_file("custom.css")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ ASDF Transform Schemas
 The ASDF Transform Schemas define a set of schemas for serializing the models defined by
 :ref:`astropy.modeling <astropy:astropy-modeling>` for the ASDF file format. These schemas
 are based upon the schemas in the :ref:`ASDF Standard <asdf-standard:asdf-standard>` and
-are packaged for use by the :ref:`ASDF <asdf:asdf>` library.
+are packaged for use by the :ref:`asdf <asdf:asdf>` library.
 
 .. note::
    This is only a schema package, to use these schemas to serialize astropy models,
@@ -38,10 +38,3 @@ Developer Resources
 
   contributing.rst
   changes.rst
-
-Index
-=====
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
- Adds the topbar global nav links for consistency across asdf subprojects
- Updated asdf (python) intersphinx url
- hide dev release suffix string e.g. ".dev+12345" in html title
- remove unused indices links