### PR TITLE
Fix CI and quantity tag bugs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions (main)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for pip (main)
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: Python 3.13 Schema validation tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
@@ -86,18 +86,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout asdf-transform-schemas
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: asdf-transform-schemas
       - name: Checkout asdf-astropy dev
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: astropy/asdf-astropy
           path: asdf-astropy
       - name: Set up Python 3.13
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.13
       - name: Install asdf-transform-schemas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: Python 3.13 Schema validation tests
+            python-version: '3.13'
+            os: ubuntu-latest
+            toxenv: py313
+
           - name: Python 3.12 Schema validation tests
             python-version: '3.12'
             os: ubuntu-latest
@@ -51,14 +56,14 @@ jobs:
             toxenv: codestyle
 
           - name: macOS
-            python-version: 3.11
+            python-version: 3.13
             os: macos-latest
-            toxenv: py311
+            toxenv: py312
 
           - name: Windows
-            python-version: 3.11
+            python-version: 3.13
             os: windows-latest
-            toxenv: py311
+            toxenv: py313
 
     steps:
       - name: Checkout code
@@ -91,10 +96,10 @@ jobs:
           fetch-depth: 0
           repository: astropy/asdf-astropy
           path: asdf-astropy
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: 3.13
       - name: Install asdf-transform-schemas
         run: cd asdf-transform-schemas && pip install .
       - name: Install asdf-astropy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           - name: Python 3.11 Schema validation tests
             python-version: '3.11'
             os: ubuntu-latest
-            toxenv: py310
+            toxenv: py311
 
           - name: Python 3.10 Schema validation tests
             python-version: '3.10'

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -70,21 +70,21 @@ jobs:
             test_command: pytest
     steps:
       - name: Checkout asdf-transform-schemas
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
           path: asdf-transform-schemas
       - name: Checkout ${{ matrix.package_name }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: ${{ matrix.repository }}
           path: target
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.13
       - name: Install asdf-transform-schemas
         run: cd asdf-transform-schemas && pip install .
       - name: Install remaining ${{ matrix.package_name }} dependencies

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -47,7 +47,7 @@ div.highlight-python:active {
 .announcement-content a {
     padding-right: 1em;
   }
-  
+
 .announcement-content a:hover {
   color: fuchsia;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,7 +139,7 @@ html_logo = ""
 html_theme_options = {
     "light_logo": "images/logo-light-mode.png",
     "dark_logo": "images/logo-dark-mode.png",
-    "announcement": topbanner, 
+    "announcement": topbanner,
 }
 
 
@@ -197,6 +197,7 @@ extensions += ["sphinx_asdf", "sphinx.ext.intersphinx", "sphinx.ext.extlinks"]  
 asdf_schema_path = "../resources/stsci.edu"
 # This is the prefix common to all schema IDs in this repository
 asdf_schema_standard_prefix = "schemas"
+
 
 def setup(app):
     app.add_css_file("custom.css")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,11 @@ name = 'asdf_transform_schemas'
 description = 'ASDF schemas for transforms'
 readme = 'README.md'
 requires-python = '>=3.9'
-license = { file = 'LICENSE' }
+license-files = ['LICENSE']
 authors = [{ name = 'The ASDF Developers', email = 'help@stsci.edu' }]
 classifiers = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
-    'Programming Language :: Python :: 3.12',
     'Development Status :: 5 - Production/Stable',
 ]
 dependencies = [
@@ -48,7 +44,7 @@ test = [
 
 [build-system]
 requires = [
-    "setuptools >=42",
+    "setuptools >77",
     "setuptools_scm[toml] >=3.4",
     "wheel",
 ]

--- a/resources/stsci.edu/schemas/affine-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/affine-1.5.0.yaml
@@ -20,6 +20,7 @@ allOf:
         anyOf:
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: array
             items:
               type: array
@@ -36,6 +37,7 @@ allOf:
         anyOf:
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: array
             items:
               type: number

--- a/resources/stsci.edu/schemas/airy-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/airy-1.4.0.yaml
@@ -19,6 +19,7 @@ allOf:
       theta_b:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           The latitude $\theta_b$ at which to minimize the error, in

--- a/resources/stsci.edu/schemas/airy_disk2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/airy_disk2d-1.2.0.yaml
@@ -21,21 +21,25 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude of the Airy function.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the maximum of the Airy function.
       y_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the maximum of the Airy function.
       radius:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The radius of the Airy disk (radius of the first zero).
 

--- a/resources/stsci.edu/schemas/arccosine1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/arccosine1d-1.2.0.yaml
@@ -21,16 +21,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.
 

--- a/resources/stsci.edu/schemas/arcsine1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/arcsine1d-1.2.0.yaml
@@ -21,16 +21,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.
 

--- a/resources/stsci.edu/schemas/arctangent1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/arctangent1d-1.2.0.yaml
@@ -21,16 +21,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.
 

--- a/resources/stsci.edu/schemas/blackbody-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/blackbody-1.2.0.yaml
@@ -26,10 +26,13 @@ allOf:
       scale:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Scale factor.
       temperature:
-        tag: "tag:astropy.org:astropy/units/quantity-1.*"
+        anyOf:
+          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
         description: Blackbody temperature.
 
     required: ['scale', 'temperature']

--- a/resources/stsci.edu/schemas/bonne_equal_area-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/bonne_equal_area-1.5.0.yaml
@@ -39,6 +39,7 @@ allOf:
       theta1:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           Bonne conformal latitude, in degrees.

--- a/resources/stsci.edu/schemas/box1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/box1d-1.2.0.yaml
@@ -25,16 +25,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Position of the center of the box model.
       width:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Width of box.
 

--- a/resources/stsci.edu/schemas/box2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/box2d-1.2.0.yaml
@@ -29,26 +29,31 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the center of the box model.
       x_width:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x width of box.
       y_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the center of the box model.
       y_width:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y width of box.
 

--- a/resources/stsci.edu/schemas/broken_power_law1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/broken_power_law1d-1.2.0.yaml
@@ -21,21 +21,25 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Model amplitude at the break point.
       x_break:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Break point.
       alpha_1:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index for x < x_break.
       alpha_2:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index for x > x_break.
 

--- a/resources/stsci.edu/schemas/conic-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/conic-1.5.0.yaml
@@ -34,6 +34,7 @@ allOf:
       sigma:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           $(\theta_1 + \theta_2) / 2$ where $\theta_1$ and $\theta_2$
@@ -43,6 +44,7 @@ allOf:
       delta:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           $(\theta_1 - \theta_2) / 2$ where $\theta_1$ and $\theta_2$

--- a/resources/stsci.edu/schemas/constant-1.6.0.yaml
+++ b/resources/stsci.edu/schemas/constant-1.6.0.yaml
@@ -14,6 +14,7 @@ allOf:
       value:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
       dimensions:
         type: integer

--- a/resources/stsci.edu/schemas/cosine1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/cosine1d-1.2.0.yaml
@@ -22,16 +22,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.
 

--- a/resources/stsci.edu/schemas/cylindrical_equal_area-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_equal_area-1.5.0.yaml
@@ -28,6 +28,7 @@ allOf:
       lambda:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           Radius of the cylinder in spherical radii, default is 1.

--- a/resources/stsci.edu/schemas/cylindrical_perspective-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_perspective-1.5.0.yaml
@@ -28,6 +28,7 @@ allOf:
       mu:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           Distance from center of sphere in the direction opposite the
@@ -37,6 +38,7 @@ allOf:
       lambda:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           Radius of the cylinder in spherical radii, default is 1.

--- a/resources/stsci.edu/schemas/disk2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/disk2d-1.2.0.yaml
@@ -29,21 +29,25 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Value of the disk function.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the center of the disk.
       y_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the center of the disk.
       R_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Radius of the disk.
 

--- a/resources/stsci.edu/schemas/drude1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/drude1d-1.2.0.yaml
@@ -26,16 +26,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Peak value.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the peak.
       fwhm:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Full width at half maximum
 

--- a/resources/stsci.edu/schemas/ellipse2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/ellipse2d-1.2.0.yaml
@@ -31,31 +31,37 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Value of the ellipse.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the center of the ellipse.
       y_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the center of the ellipse.
       a:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The length of the semimajor axis.
       b:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The length of the seminor axis.
       theta:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The rotation angle in radians of the semimajor axis. The rotation angle increase counterclockwise from the positive x axis.
 

--- a/resources/stsci.edu/schemas/exponential1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/exponential1d-1.2.0.yaml
@@ -22,11 +22,13 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude or scaling factor.
       r_core:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Denominator in exponent.
 

--- a/resources/stsci.edu/schemas/exponential_cutoff_power_law1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/exponential_cutoff_power_law1d-1.2.0.yaml
@@ -22,21 +22,25 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Model amplitude.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Reference point.
       alpha:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index.
       x_cutoff:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Cutoff point.
 

--- a/resources/stsci.edu/schemas/gaussian1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/gaussian1d-1.2.0.yaml
@@ -26,16 +26,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude.
       mean:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Mean.
       stddev:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Standard deviation.
 

--- a/resources/stsci.edu/schemas/gaussian2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/gaussian2d-1.2.0.yaml
@@ -31,31 +31,37 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude.
       x_mean:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Mean in x.
       y_mean:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Mean in y.
       x_stddev:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Standard deviation in x.
       y_stddev:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Standard deviation in y.
       theta:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Rotation angle in radians, increases counterclockwise.
 

--- a/resources/stsci.edu/schemas/king_projected_analytic1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/king_projected_analytic1d-1.2.0.yaml
@@ -26,16 +26,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude or scaling factor.
       r_core:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Core radius.
       r_tide:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Tidal radius.
 

--- a/resources/stsci.edu/schemas/linear1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/linear1d-1.2.0.yaml
@@ -14,11 +14,13 @@ allOf:
       slope:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Slope of the straight line.
       intercept:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Intercept of the straight line.
 ...

--- a/resources/stsci.edu/schemas/log_parabola1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/log_parabola1d-1.2.0.yaml
@@ -22,21 +22,25 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Model amplitude.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Reference point.
       alpha:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index.
       beta:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law curvature.
 

--- a/resources/stsci.edu/schemas/logarithmic1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/logarithmic1d-1.2.0.yaml
@@ -22,11 +22,13 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude or scaling factor.
       r_core:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Denominator in log.
 

--- a/resources/stsci.edu/schemas/lorentz1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/lorentz1d-1.2.0.yaml
@@ -26,16 +26,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Peak value.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Position of the peak.
       fwhm:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Full width at half maximum.
 

--- a/resources/stsci.edu/schemas/moffat1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/moffat1d-1.2.0.yaml
@@ -22,21 +22,25 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude of the model.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the maximum of the Moffat model.
       gamma:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Core width of the Moffat model.
       alpha:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power index of the Moffat model.
 

--- a/resources/stsci.edu/schemas/moffat2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/moffat2d-1.2.0.yaml
@@ -23,26 +23,31 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude of the model.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the maximum of the Moffat model.
       y_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the maximum of the Moffat model.
       gamma:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Core width of the Moffat model.
       alpha:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power index of the Moffat model.
 

--- a/resources/stsci.edu/schemas/multiplyscale-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/multiplyscale-1.2.0.yaml
@@ -22,6 +22,7 @@ allOf:
     properties:
       factor:
         anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - type: number
         description: Multiplication factor.

--- a/resources/stsci.edu/schemas/planar2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/planar2d-1.2.0.yaml
@@ -22,16 +22,19 @@ allOf:
       slope_x:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Slope of the stright line in x.
       slope_y:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Slope of the straight lie in y.
       intercept:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: z-intercept of the straight line.
 

--- a/resources/stsci.edu/schemas/plummer1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/plummer1d-1.2.0.yaml
@@ -22,11 +22,13 @@ allOf:
       mass:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Total mass of cluster.
       r_plum:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Scale parameter which sets the size of the cluster core.
 

--- a/resources/stsci.edu/schemas/polynomial-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/polynomial-1.3.0.yaml
@@ -43,6 +43,7 @@ allOf:
         anyOf:
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: array
     required: [coefficients]
 ...

--- a/resources/stsci.edu/schemas/power_law1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/power_law1d-1.2.0.yaml
@@ -22,16 +22,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Model amplitude at the reference point.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Reference point.
       alpha:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index.
 

--- a/resources/stsci.edu/schemas/property/bounding_box-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/property/bounding_box-1.2.0.yaml
@@ -20,7 +20,7 @@ examples:
     - A 1D bounding box
     - asdf-standard-1.6.0
     - |
-      !transform/constant-1.5.0
+      !transform/constant-1.6.0
         value: 1
         dimensions: 1
         bounding_box: !transform/property/bounding_box-1.2.0
@@ -30,7 +30,7 @@ examples:
     - A 2D bounding box
     - asdf-standard-1.6.0
     - |
-      !transform/constant-1.5.0
+      !transform/constant-1.6.0
         value: 1
         dimensions: 2
         bounding_box: !transform/property/bounding_box-1.2.0
@@ -42,15 +42,15 @@ examples:
     - A 3D bounding box
     - asdf-standard-1.6.0
     - |
-      !transform/concatenate-1.3.0
+      !transform/concatenate-1.4.0
         forward:
-          - !transform/concatenate-1.3.0
+          - !transform/concatenate-1.4.0
             forward:
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 1.0
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 2.0
-          - !transform/shift-1.3.0
+          - !transform/shift-1.4.0
             offset: 3.0
         bounding_box: !transform/property/bounding_box-1.2.0
           intervals:
@@ -62,15 +62,15 @@ examples:
     - A 3D bounding box with ignored inputs
     - asdf-standard-1.6.0
     - |
-      !transform/concatenate-1.3.0
+      !transform/concatenate-1.4.0
         forward:
-          - !transform/concatenate-1.3.0
+          - !transform/concatenate-1.4.0
             forward:
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 1.0
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 2.0
-          - !transform/shift-1.3.0
+          - !transform/shift-1.4.0
             offset: 3.0
         bounding_box: !transform/property/bounding_box-1.2.0
           intervals:
@@ -81,7 +81,8 @@ examples:
 definitions:
   bound:
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
+      - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - type: number
 
   interval:

--- a/resources/stsci.edu/schemas/property/compound_bounding_box-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/property/compound_bounding_box-1.2.0.yaml
@@ -20,7 +20,7 @@ examples:
     - A compound bounding box with one selector_args and 1D bounding_box
     - asdf-standard-1.6.0
     - |
-      !transform/constant-1.5.0
+      !transform/constant-1.6.0
         value: 1
         dimensions: 2
         bounding_box: !transform/property/compound_bounding_box-1.2.0
@@ -29,26 +29,26 @@ examples:
               ignore: true
           cbbox:
             - key: [0] # value of input x is 0 to select this box
-              bbox: !transform/property/bounding_box-1.1.0
+              bbox: !transform/property/bounding_box-1.2.0
                 intervals:
                   y: [1.0, 2.0]
             - key: [3] # value of input x is 3 to select this box
-              bbox: !transform/property/bounding_box-1.1.0
+              bbox: !transform/property/bounding_box-1.2.0
                 intervals:
                   y: [4.0, 5.0]
   -
     - A compound bounding box with one selector_args and 2D bounding_box
     - asdf-standard-1.6.0
     - |
-      !transform/concatenate-1.3.0
+      !transform/concatenate-1.4.0
         forward:
-          - !transform/concatenate-1.3.0
+          - !transform/concatenate-1.4.0
             forward:
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 1.0
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 2.0
-          - !transform/shift-1.3.0
+          - !transform/shift-1.4.0
             offset: 3.0
         bounding_box: !transform/property/compound_bounding_box-1.2.0
           selector_args:
@@ -56,12 +56,12 @@ examples:
               ignore: true
           cbbox:
             - key: [0] # value of input x is 0 to select this box
-              bbox: !transform/property/bounding_box-1.1.0
+              bbox: !transform/property/bounding_box-1.2.0
                 intervals:
                   x0: [1.0, 2.0]
                   x1: [3.0, 4.0]
             - key: [5] # value of input x is 5 to select this box
-              bbox: !transform/property/bounding_box-1.1.0
+              bbox: !transform/property/bounding_box-1.2.0
                 intervals:
                   x0: [6.0, 7.0]
                   x1: [8.0, 9.0]
@@ -70,15 +70,15 @@ examples:
     - A compound bounding box with two selector_args and 1D bounding_box
     - asdf-standard-1.6.0
     - |
-      !transform/concatenate-1.3.0
+      !transform/concatenate-1.4.0
         forward:
-          - !transform/concatenate-1.3.0
+          - !transform/concatenate-1.4.0
             forward:
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 1.0
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 2.0
-          - !transform/shift-1.3.0
+          - !transform/shift-1.4.0
             offset: 3.0
         bounding_box: !transform/property/compound_bounding_box-1.2.0
           selector_args:
@@ -88,26 +88,26 @@ examples:
               ignore: true
           cbbox:
             - key: [0, 1] # both value of input x0 is 0 and value of input x1 is 1 to select this box
-              bbox: !transform/property/bounding_box-1.1.0
+              bbox: !transform/property/bounding_box-1.2.0
                 intervals:
                   x: [2.0, 3.0]
             - key: [4, 5] # both value of input x0 is 4 and value of input x1 is 5 to select this box
-              bbox: !transform/property/bounding_box-1.1.0
+              bbox: !transform/property/bounding_box-1.2.0
                 intervals:
                   x: [6.0, 7.0]
   -
     - A compound bounding box with one selector_args and 1D bounding_box
     - asdf-standard-1.6.0
     - |
-      !transform/concatenate-1.3.0
+      !transform/concatenate-1.4.0
         forward:
-          - !transform/concatenate-1.3.0
+          - !transform/concatenate-1.4.0
             forward:
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 1.0
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 2.0
-          - !transform/shift-1.3.0
+          - !transform/shift-1.4.0
             offset: 3.0
         bounding_box: !transform/property/compound_bounding_box-1.2.0
           selector_args:
@@ -115,11 +115,11 @@ examples:
               ignore: true
           cbbox:
             - key: [0] # both value of input x is 0
-              bbox: !transform/property/bounding_box-1.1.0
+              bbox: !transform/property/bounding_box-1.2.0
                 intervals:
                   x0: [2.0, 3.0]
             - key: [1] # both value of input x is 1
-              bbox: !transform/property/bounding_box-1.1.0
+              bbox: !transform/property/bounding_box-1.2.0
                 intervals:
                   x0: [6.0, 7.0]
           ignore: [x1]
@@ -127,19 +127,19 @@ examples:
     - A compound bounding box with two selector_args and 2D bounding_box
     - asdf-standard-1.6.0
     - |
-      !transform/concatenate-1.3.0
+      !transform/concatenate-1.4.0
         forward:
-          - !transform/concatenate-1.3.0
+          - !transform/concatenate-1.4.0
             forward:
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 1.0
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 2.0
-          - !transform/concatenate-1.3.0
+          - !transform/concatenate-1.4.0
             forward:
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 3.0
-              - !transform/shift-1.3.0
+              - !transform/shift-1.4.0
                 offset: 4.0
         bounding_box: !transform/property/compound_bounding_box-1.2.0
           selector_args:
@@ -149,12 +149,12 @@ examples:
               ignore: true
           cbbox:
             - key: [0, 1] # both value of input x00 is 0 and value of input x10 is 1 to select this box
-              bbox: !transform/property/bounding_box-1.1.0
+              bbox: !transform/property/bounding_box-1.2.0
                 intervals:
                   x01: [2.0, 3.0]
                   x11: [4.0, 5.0]
             - key: [6, 7] # both value of input x00 is 6 and value of input x10 is 7 to select this box
-              bbox: !transform/property/bounding_box-1.1.0
+              bbox: !transform/property/bounding_box-1.2.0
                 intervals:
                   x01: [8.0, 9.0]
                   x11: [10.0, 11.0]

--- a/resources/stsci.edu/schemas/redshift_scale_factor-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/redshift_scale_factor-1.2.0.yaml
@@ -22,6 +22,7 @@ allOf:
       z:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Redshift value.
 

--- a/resources/stsci.edu/schemas/remap_axes-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/remap_axes-1.5.0.yaml
@@ -48,7 +48,7 @@ examples:
         implementations are free to normalize it thusly:
     - asdf-standard-1.6.0
     - |
-        !transform/concatenate-1.3.0
+        !transform/concatenate-1.4.0
           forward:
             - !transform/remap_axes-1.5.0
               mapping: [0]

--- a/resources/stsci.edu/schemas/ricker_wavelet1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/ricker_wavelet1d-1.2.0.yaml
@@ -22,16 +22,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Peak value.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Position of the peak.
       sigma:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Width of the Ricker wavelet.
 

--- a/resources/stsci.edu/schemas/ricker_wavelet2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/ricker_wavelet2d-1.2.0.yaml
@@ -22,21 +22,25 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the peak.
       y_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the peak.
       sigma:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Width of the Ricker wavelet.
 

--- a/resources/stsci.edu/schemas/ring2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/ring2d-1.2.0.yaml
@@ -30,26 +30,31 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Value of the disk function.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x center position of the disk.
       y_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y center position of the disk.
       r_in:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Inner radius of the ring.
       width:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Width of the ring.
 

--- a/resources/stsci.edu/schemas/rotate2d-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/rotate2d-1.5.0.yaml
@@ -16,6 +16,7 @@ allOf:
       angle:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Angle, in degrees.
     required: [angle]

--- a/resources/stsci.edu/schemas/rotate3d-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/rotate3d-1.5.0.yaml
@@ -28,16 +28,19 @@ allOf:
       phi:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Angle, in degrees.
       theta:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Angle, in degrees.
       psi:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Angle, in degrees.
       direction:

--- a/resources/stsci.edu/schemas/rotate_sequence_3d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/rotate_sequence_3d-1.2.0.yaml
@@ -27,6 +27,7 @@ allOf:
         items:
           anyOf:
             - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+            - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
             - type: number
         description: |
           The angles of rotation in units of deg.

--- a/resources/stsci.edu/schemas/scale-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/scale-1.4.0.yaml
@@ -13,6 +13,7 @@ allOf:
     properties:
       factor:
         anyOf:
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - type: number
         description: Scale factor.

--- a/resources/stsci.edu/schemas/schechter1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/schechter1d-1.2.0.yaml
@@ -22,6 +22,7 @@ allOf:
     properties:
       phi_star:
         anyOf:
+          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: >
@@ -33,6 +34,7 @@ allOf:
           cuts off into the exponential form.
       alpha:
         anyOf:
+          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: >

--- a/resources/stsci.edu/schemas/sersic1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/sersic1d-1.2.0.yaml
@@ -22,16 +22,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Surface brightness at r_eff.
       r_eff:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Effective (half-light) radius.
       n:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Sersic index.
 

--- a/resources/stsci.edu/schemas/sersic2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/sersic2d-1.2.0.yaml
@@ -22,36 +22,43 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Surface brightness at r_eff.
       r_eff:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Effective (half-light) radius.
       n:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Sersic index.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the center.
       y_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the center.
       ellip:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Ellipticity.
       theta:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Rotation angle in radians, increases counterclockwise from the positive x-axis.
 

--- a/resources/stsci.edu/schemas/shift-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/shift-1.4.0.yaml
@@ -14,6 +14,7 @@ allOf:
       offset:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Offset in one direction.
     required: [offset]

--- a/resources/stsci.edu/schemas/sine1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/sine1d-1.2.0.yaml
@@ -22,16 +22,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.
 

--- a/resources/stsci.edu/schemas/slant_orthographic-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/slant_orthographic-1.4.0.yaml
@@ -30,6 +30,7 @@ allOf:
       xi:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Obliqueness parameter, first equation of the slant
                      orthographic projection.
@@ -38,6 +39,7 @@ allOf:
       eta:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Obliqueness parameter, second equation of the slant
                      orthographic projection.

--- a/resources/stsci.edu/schemas/slant_zenithal_perspective-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/slant_zenithal_perspective-1.4.0.yaml
@@ -30,6 +30,7 @@ allOf:
       mu:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           Distance from point of projection to center of sphere in
@@ -39,6 +40,7 @@ allOf:
       phi0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           The longitude $\phi_0$ of the reference point, in degrees.
@@ -47,6 +49,7 @@ allOf:
       theta0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           The latitude $\theta_0$ of the reference point, in degrees.

--- a/resources/stsci.edu/schemas/smoothly_broken_power_law1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/smoothly_broken_power_law1d-1.2.0.yaml
@@ -22,26 +22,31 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Model amplitude at the break point.
       x_break:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Break point.
       alpha_1:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index for x < x_break.
       alpha_2:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index for x > x_break.
       delta:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Smoothness parameter.
 

--- a/resources/stsci.edu/schemas/tabular-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/tabular-1.4.0.yaml
@@ -21,6 +21,7 @@ allOf:
           - type: array
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       points:
         type: array
         items:
@@ -28,6 +29,7 @@ allOf:
             - type: array
             - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
             - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+            - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
         description: |
           Grid values - each row in the array corresponds to a dimension
           in the lookup table. The grid does not have to be regular.

--- a/resources/stsci.edu/schemas/tangent1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/tangent1d-1.2.0.yaml
@@ -22,16 +22,19 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.
 

--- a/resources/stsci.edu/schemas/transform-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/transform-1.4.0.yaml
@@ -117,7 +117,8 @@ definitions:
 
   quantity_bound:
     anyOf:
-      - tag: tag:stsci.edu:asdf/unit/quantity-1.*
+      - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - type: number
 
   interval:

--- a/resources/stsci.edu/schemas/trapezoid1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/trapezoid1d-1.2.0.yaml
@@ -27,21 +27,25 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude of the trapezoid.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Center position of the trapezoid.
       width:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Width of the constant part of the trapezoid.
       slope:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Slope of the tails of the trapezoid.
 

--- a/resources/stsci.edu/schemas/trapezoid_disk2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/trapezoid_disk2d-1.2.0.yaml
@@ -29,26 +29,31 @@ allOf:
       amplitude:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude of the trapezoid.
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x center position of the trapezoid.
       y_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y center position of the trapezoid.
       R_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Radius of the constant part of the trapezoid.
       slope:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Slope of the tails of the trapezoid in x direction.
 

--- a/resources/stsci.edu/schemas/voigt1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/voigt1d-1.2.0.yaml
@@ -22,21 +22,25 @@ allOf:
       x_0:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Position of the peak.
       amplitude_L:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The Lorentzian amplitude.
       fwhm_L:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The Lorentzian full width at half maximum.
       fwhm_G:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The Gaussian full width at half maximum.
 

--- a/resources/stsci.edu/schemas/zenithal_perspective-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_perspective-1.5.0.yaml
@@ -39,6 +39,7 @@ allOf:
       mu:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           Distance from point of projection to center of sphere in
@@ -48,6 +49,7 @@ allOf:
       gamma:
         anyOf:
           - tag: "tag:astropy.org:astropy/units/quantity-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
           Look angle, in degrees.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 
+import asdf
 import pytest
 import yaml
-
-import asdf
 
 
 def get_latest_schema_uris(resource_paths):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,4 @@
 import asdf
-import pytest
 import yaml
 
 

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_manifest_tag_order(latest_manifest):
     """Tags should be sorted alphabetically"""
     tag_uris = [tag_def["tag_uri"] for tag_def in latest_manifest["tags"]]

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -15,6 +15,10 @@ ALLOWED_REFS = (
     r"^#.*$",
 )
 
+ASDF_QUANTITY_TAG = "tag:stsci.edu:asdf/unit/quantity-1.*"
+ASTROPY_QUANTITY_TAG = "tag:astropy.org:astropy/units/quantity-1.*"
+QUANTITY_TAGS = {ASDF_QUANTITY_TAG, ASTROPY_QUANTITY_TAG}
+
 
 def test_only_known_refs(latest_schema):
     """Latest schemas should only contain specific refs"""
@@ -36,3 +40,33 @@ def test_wildcard_tags(latest_schema):
             pattern = node["tag"]
             if "*" not in pattern:
                 assert False, f"tag pattern missing wildcard: {pattern}"
+
+
+def test_quantity_tag(latest_schema):
+    # we walk_and_modify here to use postorder
+
+    def callback(node):
+        if not isinstance(node, dict):
+            return node
+        if "anyOf" in node:
+            # check if this anyof includes tag: quantity
+            seen = set()
+            for sub in node["anyOf"]:
+                if not isinstance(sub, dict):
+                    continue
+                if "tag" not in sub:
+                    continue
+                if sub["tag"] in QUANTITY_TAGS:
+                    seen.add(sub["tag"])
+
+            if seen:
+                # if a tag: quantity was found, check both were found
+                assert seen == QUANTITY_TAGS, f"anyOf {node} missing: {QUANTITY_TAGS - seen}"
+                # remove the anyof so the code below can check for quantity
+                # tags not in anyof
+                return {k: v for k, v in node.items() if k != "anyOf"}
+        if tag := node.get("tag"):
+            assert tag not in QUANTITY_TAGS, f"quantity tag {tag} must be in an anyOf with all quantity tags: {QUANTITY_TAGS}"
+        return node
+
+    asdf.treeutil.walk_and_modify(latest_schema, callback, postorder=False)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2,8 +2,6 @@ import re
 
 import asdf
 
-import pytest
-
 ALLOWED_REFS = (
     r"^transform-[0-9.]+$",
     r"^conic-[0-9.]+$",
@@ -66,7 +64,9 @@ def test_quantity_tag(latest_schema):
                 # tags not in anyof
                 return {k: v for k, v in node.items() if k != "anyOf"}
         if tag := node.get("tag"):
-            assert tag not in QUANTITY_TAGS, f"quantity tag {tag} must be in an anyOf with all quantity tags: {QUANTITY_TAGS}"
+            assert (
+                tag not in QUANTITY_TAGS
+            ), f"quantity tag {tag} must be in an anyOf with all quantity tags: {QUANTITY_TAGS}"
         return node
 
     asdf.treeutil.walk_and_modify(latest_schema, callback, postorder=False)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, py312, black, flake8
+envlist = py39, py310, py311, py312, py313, black, flake8
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
This PR:
- updates pyproject.toml to avoid setuptools deprecation warnings about license definitions
- updates/fixes the ci 
- updates schemas to include both astropy and asdf quantity tags (when either is used)

I marked this as "no-changelog-entry-needed" as the schema fixes ideally would have been in https://github.com/asdf-format/asdf-transform-schemas/pull/120. Unfortunately the CI disabled itself from inactivity and so it didn't run and catch the bugs fixed in this PR. Since no release has been made the changelog from #120 covers these changes.

After this PR is merged branch protections will be updated to require:
- style
- python 3.13
- docs
- changelog
- twine (build)
- mac
- windows