### PR TITLE
expand quantity anyof test to include unit

### DIFF
--- a/resources/stsci.edu/schemas/affine-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/affine-1.5.0.yaml
@@ -19,7 +19,6 @@ allOf:
           representing the linear transformation in an affine transform.
         anyOf:
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: array
             items:
@@ -36,7 +35,6 @@ allOf:
           representing the translation in an affine transform.
         anyOf:
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: array
             items:

--- a/resources/stsci.edu/schemas/airy-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/airy-1.4.0.yaml
@@ -18,7 +18,6 @@ allOf:
     properties:
       theta_b:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |

--- a/resources/stsci.edu/schemas/airy_disk2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/airy_disk2d-1.2.0.yaml
@@ -20,25 +20,21 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude of the Airy function.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the maximum of the Airy function.
       y_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the maximum of the Airy function.
       radius:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The radius of the Airy disk (radius of the first zero).

--- a/resources/stsci.edu/schemas/arccosine1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/arccosine1d-1.2.0.yaml
@@ -20,19 +20,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.

--- a/resources/stsci.edu/schemas/arcsine1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/arcsine1d-1.2.0.yaml
@@ -20,19 +20,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.

--- a/resources/stsci.edu/schemas/arctangent1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/arctangent1d-1.2.0.yaml
@@ -20,19 +20,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.

--- a/resources/stsci.edu/schemas/blackbody-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/blackbody-1.2.0.yaml
@@ -25,13 +25,11 @@ allOf:
     properties:
       scale:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Scale factor.
       temperature:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
         description: Blackbody temperature.
 

--- a/resources/stsci.edu/schemas/bonne_equal_area-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/bonne_equal_area-1.5.0.yaml
@@ -38,7 +38,6 @@ allOf:
     properties:
       theta1:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |

--- a/resources/stsci.edu/schemas/box1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/box1d-1.2.0.yaml
@@ -24,19 +24,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Position of the center of the box model.
       width:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Width of box.

--- a/resources/stsci.edu/schemas/box2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/box2d-1.2.0.yaml
@@ -28,31 +28,26 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the center of the box model.
       x_width:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x width of box.
       y_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the center of the box model.
       y_width:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y width of box.

--- a/resources/stsci.edu/schemas/broken_power_law1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/broken_power_law1d-1.2.0.yaml
@@ -20,25 +20,21 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Model amplitude at the break point.
       x_break:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Break point.
       alpha_1:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index for x < x_break.
       alpha_2:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index for x > x_break.

--- a/resources/stsci.edu/schemas/conic-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/conic-1.5.0.yaml
@@ -33,7 +33,6 @@ allOf:
 
       sigma:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
@@ -43,7 +42,6 @@ allOf:
 
       delta:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |

--- a/resources/stsci.edu/schemas/constant-1.6.0.yaml
+++ b/resources/stsci.edu/schemas/constant-1.6.0.yaml
@@ -13,7 +13,6 @@ allOf:
     properties:
       value:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
       dimensions:

--- a/resources/stsci.edu/schemas/cosine1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/cosine1d-1.2.0.yaml
@@ -21,19 +21,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.

--- a/resources/stsci.edu/schemas/cylindrical_equal_area-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_equal_area-1.5.0.yaml
@@ -27,7 +27,6 @@ allOf:
     properties:
       lambda:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |

--- a/resources/stsci.edu/schemas/cylindrical_perspective-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/cylindrical_perspective-1.5.0.yaml
@@ -27,7 +27,6 @@ allOf:
     properties:
       mu:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
@@ -37,7 +36,6 @@ allOf:
 
       lambda:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |

--- a/resources/stsci.edu/schemas/disk2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/disk2d-1.2.0.yaml
@@ -28,25 +28,21 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Value of the disk function.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the center of the disk.
       y_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the center of the disk.
       R_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Radius of the disk.

--- a/resources/stsci.edu/schemas/drude1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/drude1d-1.2.0.yaml
@@ -25,19 +25,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Peak value.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the peak.
       fwhm:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Full width at half maximum

--- a/resources/stsci.edu/schemas/ellipse2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/ellipse2d-1.2.0.yaml
@@ -30,37 +30,31 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Value of the ellipse.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the center of the ellipse.
       y_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the center of the ellipse.
       a:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The length of the semimajor axis.
       b:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The length of the seminor axis.
       theta:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The rotation angle in radians of the semimajor axis. The rotation angle increase counterclockwise from the positive x axis.

--- a/resources/stsci.edu/schemas/exponential1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/exponential1d-1.2.0.yaml
@@ -21,13 +21,11 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude or scaling factor.
       r_core:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Denominator in exponent.

--- a/resources/stsci.edu/schemas/exponential_cutoff_power_law1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/exponential_cutoff_power_law1d-1.2.0.yaml
@@ -21,25 +21,21 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Model amplitude.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Reference point.
       alpha:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index.
       x_cutoff:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Cutoff point.

--- a/resources/stsci.edu/schemas/gaussian1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/gaussian1d-1.2.0.yaml
@@ -25,19 +25,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude.
       mean:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Mean.
       stddev:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Standard deviation.

--- a/resources/stsci.edu/schemas/gaussian2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/gaussian2d-1.2.0.yaml
@@ -30,37 +30,31 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude.
       x_mean:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Mean in x.
       y_mean:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Mean in y.
       x_stddev:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Standard deviation in x.
       y_stddev:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Standard deviation in y.
       theta:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Rotation angle in radians, increases counterclockwise.

--- a/resources/stsci.edu/schemas/king_projected_analytic1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/king_projected_analytic1d-1.2.0.yaml
@@ -25,19 +25,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude or scaling factor.
       r_core:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Core radius.
       r_tide:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Tidal radius.

--- a/resources/stsci.edu/schemas/linear1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/linear1d-1.2.0.yaml
@@ -13,13 +13,11 @@ allOf:
     properties:
       slope:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Slope of the straight line.
       intercept:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Intercept of the straight line.

--- a/resources/stsci.edu/schemas/log_parabola1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/log_parabola1d-1.2.0.yaml
@@ -21,25 +21,21 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Model amplitude.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Reference point.
       alpha:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index.
       beta:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law curvature.

--- a/resources/stsci.edu/schemas/logarithmic1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/logarithmic1d-1.2.0.yaml
@@ -21,13 +21,11 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude or scaling factor.
       r_core:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Denominator in log.

--- a/resources/stsci.edu/schemas/lorentz1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/lorentz1d-1.2.0.yaml
@@ -25,19 +25,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Peak value.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Position of the peak.
       fwhm:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Full width at half maximum.

--- a/resources/stsci.edu/schemas/moffat1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/moffat1d-1.2.0.yaml
@@ -21,25 +21,21 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude of the model.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the maximum of the Moffat model.
       gamma:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Core width of the Moffat model.
       alpha:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power index of the Moffat model.

--- a/resources/stsci.edu/schemas/moffat2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/moffat2d-1.2.0.yaml
@@ -22,31 +22,26 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude of the model.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the maximum of the Moffat model.
       y_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the maximum of the Moffat model.
       gamma:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Core width of the Moffat model.
       alpha:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power index of the Moffat model.

--- a/resources/stsci.edu/schemas/multiplyscale-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/multiplyscale-1.2.0.yaml
@@ -23,7 +23,6 @@ allOf:
       factor:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - type: number
         description: Multiplication factor.
     required: [factor]

--- a/resources/stsci.edu/schemas/planar2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/planar2d-1.2.0.yaml
@@ -21,19 +21,16 @@ allOf:
     properties:
       slope_x:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Slope of the stright line in x.
       slope_y:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Slope of the straight lie in y.
       intercept:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: z-intercept of the straight line.

--- a/resources/stsci.edu/schemas/plummer1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/plummer1d-1.2.0.yaml
@@ -21,13 +21,11 @@ allOf:
     properties:
       mass:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Total mass of cluster.
       r_plum:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Scale parameter which sets the size of the cluster core.

--- a/resources/stsci.edu/schemas/polynomial-1.3.0.yaml
+++ b/resources/stsci.edu/schemas/polynomial-1.3.0.yaml
@@ -42,7 +42,6 @@ allOf:
           An array with coefficients.
         anyOf:
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: array
     required: [coefficients]

--- a/resources/stsci.edu/schemas/power_law1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/power_law1d-1.2.0.yaml
@@ -21,19 +21,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Model amplitude at the reference point.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Reference point.
       alpha:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index.

--- a/resources/stsci.edu/schemas/property/bounding_box-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/property/bounding_box-1.2.0.yaml
@@ -81,7 +81,6 @@ examples:
 definitions:
   bound:
     anyOf:
-      - tag: "tag:astropy.org:astropy/units/quantity-1.*"
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - type: number
 

--- a/resources/stsci.edu/schemas/redshift_scale_factor-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/redshift_scale_factor-1.2.0.yaml
@@ -21,7 +21,6 @@ allOf:
     properties:
       z:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Redshift value.

--- a/resources/stsci.edu/schemas/ricker_wavelet1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/ricker_wavelet1d-1.2.0.yaml
@@ -21,19 +21,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Peak value.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Position of the peak.
       sigma:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Width of the Ricker wavelet.

--- a/resources/stsci.edu/schemas/ricker_wavelet2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/ricker_wavelet2d-1.2.0.yaml
@@ -21,25 +21,21 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the peak.
       y_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the peak.
       sigma:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Width of the Ricker wavelet.

--- a/resources/stsci.edu/schemas/ring2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/ring2d-1.2.0.yaml
@@ -29,31 +29,26 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Value of the disk function.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x center position of the disk.
       y_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y center position of the disk.
       r_in:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Inner radius of the ring.
       width:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Width of the ring.

--- a/resources/stsci.edu/schemas/rotate2d-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/rotate2d-1.5.0.yaml
@@ -15,7 +15,6 @@ allOf:
     properties:
       angle:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Angle, in degrees.

--- a/resources/stsci.edu/schemas/rotate3d-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/rotate3d-1.5.0.yaml
@@ -27,19 +27,16 @@ allOf:
     properties:
       phi:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Angle, in degrees.
       theta:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Angle, in degrees.
       psi:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Angle, in degrees.

--- a/resources/stsci.edu/schemas/rotate_sequence_3d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/rotate_sequence_3d-1.2.0.yaml
@@ -26,7 +26,6 @@ allOf:
         type: array
         items:
           anyOf:
-            - tag: "tag:astropy.org:astropy/units/quantity-1.*"
             - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
             - type: number
         description: |

--- a/resources/stsci.edu/schemas/scale-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/scale-1.4.0.yaml
@@ -14,7 +14,6 @@ allOf:
       factor:
         anyOf:
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - type: number
         description: Scale factor.
     required: [factor]

--- a/resources/stsci.edu/schemas/schechter1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/schechter1d-1.2.0.yaml
@@ -22,7 +22,6 @@ allOf:
     properties:
       phi_star:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: >
@@ -34,7 +33,6 @@ allOf:
           cuts off into the exponential form.
       alpha:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: >

--- a/resources/stsci.edu/schemas/sersic1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/sersic1d-1.2.0.yaml
@@ -21,19 +21,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Surface brightness at r_eff.
       r_eff:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Effective (half-light) radius.
       n:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Sersic index.

--- a/resources/stsci.edu/schemas/sersic2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/sersic2d-1.2.0.yaml
@@ -21,43 +21,36 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Surface brightness at r_eff.
       r_eff:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Effective (half-light) radius.
       n:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Sersic index.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x position of the center.
       y_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y position of the center.
       ellip:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Ellipticity.
       theta:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Rotation angle in radians, increases counterclockwise from the positive x-axis.

--- a/resources/stsci.edu/schemas/shift-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/shift-1.4.0.yaml
@@ -13,7 +13,6 @@ allOf:
     properties:
       offset:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Offset in one direction.

--- a/resources/stsci.edu/schemas/sine1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/sine1d-1.2.0.yaml
@@ -21,19 +21,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.

--- a/resources/stsci.edu/schemas/slant_orthographic-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/slant_orthographic-1.4.0.yaml
@@ -29,7 +29,6 @@ allOf:
     properties:
       xi:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Obliqueness parameter, first equation of the slant
@@ -38,7 +37,6 @@ allOf:
 
       eta:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Obliqueness parameter, second equation of the slant

--- a/resources/stsci.edu/schemas/slant_zenithal_perspective-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/slant_zenithal_perspective-1.4.0.yaml
@@ -29,7 +29,6 @@ allOf:
     properties:
       mu:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
@@ -39,7 +38,6 @@ allOf:
 
       phi0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
@@ -48,7 +46,6 @@ allOf:
 
       theta0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |

--- a/resources/stsci.edu/schemas/smoothly_broken_power_law1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/smoothly_broken_power_law1d-1.2.0.yaml
@@ -21,31 +21,26 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Model amplitude at the break point.
       x_break:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Break point.
       alpha_1:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index for x < x_break.
       alpha_2:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Power law index for x > x_break.
       delta:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Smoothness parameter.

--- a/resources/stsci.edu/schemas/tabular-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/tabular-1.4.0.yaml
@@ -20,7 +20,6 @@ allOf:
         anyOf:
           - type: array
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       points:
         type: array
@@ -28,7 +27,6 @@ allOf:
           anyOf:
             - type: array
             - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-            - tag: "tag:astropy.org:astropy/units/quantity-1.*"
             - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
         description: |
           Grid values - each row in the array corresponds to a dimension

--- a/resources/stsci.edu/schemas/tangent1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/tangent1d-1.2.0.yaml
@@ -21,19 +21,16 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation amplitude.
       frequency:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation frequency.
       phase:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Oscillation phase.

--- a/resources/stsci.edu/schemas/transform-1.4.0.yaml
+++ b/resources/stsci.edu/schemas/transform-1.4.0.yaml
@@ -117,7 +117,6 @@ definitions:
 
   quantity_bound:
     anyOf:
-      - tag: "tag:astropy.org:astropy/units/quantity-1.*"
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
       - type: number
 

--- a/resources/stsci.edu/schemas/trapezoid1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/trapezoid1d-1.2.0.yaml
@@ -26,25 +26,21 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude of the trapezoid.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Center position of the trapezoid.
       width:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Width of the constant part of the trapezoid.
       slope:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Slope of the tails of the trapezoid.

--- a/resources/stsci.edu/schemas/trapezoid_disk2d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/trapezoid_disk2d-1.2.0.yaml
@@ -28,31 +28,26 @@ allOf:
     properties:
       amplitude:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Amplitude of the trapezoid.
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: x center position of the trapezoid.
       y_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: y center position of the trapezoid.
       R_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Radius of the constant part of the trapezoid.
       slope:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Slope of the tails of the trapezoid in x direction.

--- a/resources/stsci.edu/schemas/voigt1d-1.2.0.yaml
+++ b/resources/stsci.edu/schemas/voigt1d-1.2.0.yaml
@@ -21,25 +21,21 @@ allOf:
     properties:
       x_0:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: Position of the peak.
       amplitude_L:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The Lorentzian amplitude.
       fwhm_L:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The Lorentzian full width at half maximum.
       fwhm_G:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: The Gaussian full width at half maximum.

--- a/resources/stsci.edu/schemas/zenithal_perspective-1.5.0.yaml
+++ b/resources/stsci.edu/schemas/zenithal_perspective-1.5.0.yaml
@@ -38,7 +38,6 @@ allOf:
     properties:
       mu:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |
@@ -48,7 +47,6 @@ allOf:
 
       gamma:
         anyOf:
-          - tag: "tag:astropy.org:astropy/units/quantity-1.*"
           - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
           - type: number
         description: |

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -14,7 +14,6 @@ ALLOWED_REFS = (
     r"^#.*$",
 )
 
-QUANTITY_TAGS = {"tag:stsci.edu:asdf/unit/quantity-1.*", "tag:astropy.org:astropy/units/quantity-1.*"}
 UNIT_TAGS = {"tag:stsci.edu:asdf/unit/unit-1.*", "tag:astropy.org:astropy/units/unit-1.*"}
 
 
@@ -40,10 +39,10 @@ def test_wildcard_tags(latest_schema):
                 assert False, f"tag pattern missing wildcard: {pattern}"
 
 
-@pytest.mark.parametrize("tag_set", (QUANTITY_TAGS, UNIT_TAGS))
+@pytest.mark.parametrize("tag_set", (UNIT_TAGS,))
 def test_tags_in_allof(latest_schema, tag_set):
     """
-    Test that some tags (quantity and unit) where the
+    Test that some tags (unit) where the
     tag used depends on the value are always referenced in an
     allof containing all tags.
     """


### PR DESCRIPTION
This PR fixes the unit test checking for `anyOf` usage for quantity to only test for unit tag usage and remove references to the non-existent astropy quantity tag that were added in https://github.com/asdf-format/asdf-transform-schemas/pull/120